### PR TITLE
Make public datasets public

### DIFF
--- a/ckanext/restricted/fanstatic/restricted_ui.js
+++ b/ckanext/restricted/fanstatic/restricted_ui.js
@@ -7,10 +7,13 @@ ckan.module('restricted_popup', function ($) {
   return {
     initialize: function () {
       console.log("Initialize", this.el);
-      this.el.popover({title: this.options.title,
-                       content: this.options.content,
-		       html: true,
-                       placement: 'left'});
+      this.el.popover({
+        title: this.options.title,
+        content: this.options.content,
+		    html: true,
+        placement: 'left',
+        trigger: 'hover'
+      });
     }
   };
 });

--- a/ckanext/restricted/logic.py
+++ b/ckanext/restricted/logic.py
@@ -77,13 +77,13 @@ def restricted_check_user_resource_access(user, resource_dict, package_dict):
     allowed_users = restricted_dict.get('allowed_users', [])
     allowed_organizations = restricted_dict.get('allowed_organizations', [])
     # Public resources
-    # Only Registered users have access to data
+    if restricted_level == 'public':
+        return {'success': True}
+    # Registered user
     if not user:
         return {
             'success': False,
             'msg': 'Resource access restricted to registered users'}
-    if restricted_level == 'public':
-        return {'success': True}
     # Since we have a user, check if it is in the allowed list
     if user in allowed_users:
         return {'success': True}

--- a/ckanext/restricted/templates/package/snippets/resource_item.html
+++ b/ckanext/restricted/templates/package/snippets/resource_item.html
@@ -14,20 +14,19 @@
   {{ super() }}
   {% if can_edit %}
     {% if "restricted" not in res  or pkg["private"] %}
-     {{_('Only accessible by users in your organisation')}}
+      {{_('(Only accessible by users in your organisation)')}}
+    {% else %}
+      {% set restricted = h.restricted_json_loads(res["restricted"]) %}
+      {% if restricted["level"] == "public" %}
+        {{_('(Public)')}}
       {% else %}
-       {% set restricted = h.restricted_json_loads(res["restricted"]) %}
-       {% if restricted["level"] == "public" %}
-        {{_('Accessible by all registered users')}}
-       {% else %}
-
         {% set org_string = "<br />".join(restricted.get("allowed_organisations", "None").split(",") + [pkg.organization.title]) %}
-       {% set usr_string = "<br />".join(restricted.get("allowed_users", "None").split(",")) %}
+        {% set usr_string = "<br />".join(restricted.get("allowed_users", "None").split(",")) %}
 
-      {{_('Accsesible by specified ')}} <a href="#" data-module="restricted_popup" data-module-title="Access granted to organizations" data-module-content="{{org_string}}">organisations</a> and <a href="#" data-module="restricted_popup" data-module-title="Access granted to users" data-module-content="{{usr_string}}">users</a>.
-       {% endif %}
-   {% endif %}
-  {% endif%}
+        {{_('Accsesible by specified ')}} <a href="#" data-module="restricted_popup" data-module-title="Access granted to organizations" data-module-content="{{org_string}}">organisations</a> and <a href="#" data-module="restricted_popup" data-module-title="Access granted to users" data-module-content="{{usr_string}}">users</a>.
+      {% endif %}
+    {% endif %}
+  {% endif %}
   {% else %}
   <span class="restricted-item">
     <a class="heading restricted-item" disabled="true" href="#" title="{{ res.name or res.description }}">{{ h.resource_display_name(res) | truncate(35) }} {{ _('Unauthorized') }} <span class="format-label" property="dc:format" data-format="{{ res.format.lower() or 'data' }}">{{ res.format }}</span>{{ h.popular('views', res.tracking_summary.total, min=10) }}</a></span>
@@ -52,5 +51,3 @@
   {% endif%}
   {% endif %}
   {% endblock %}
-
-

--- a/ckanext/restricted/tests/test_config.ini
+++ b/ckanext/restricted/tests/test_config.ini
@@ -1,0 +1,4 @@
+[app:main]
+use = config:/usr/lib/ckan/venv/src/ckan/test-core.ini
+ckan.site_title = My Test CKAN Site
+ckan.site_description = A test site for testing my CKAN extension

--- a/ckanext/restricted/tests/test_plugin.py
+++ b/ckanext/restricted/tests/test_plugin.py
@@ -8,7 +8,7 @@ import ckan.tests.factories as factories
 import ckan.logic as logic
 
 
-class TestRestrictedPlugin(object):
+class TestExampleIAuthFunctionsPluginV6ParentAuthFunctions(object):
     '''Tests for the ckanext.example_iauthfunctions.plugin module.
 
     Specifically tests that overriding parent auth functions will cause
@@ -37,24 +37,13 @@ class TestRestrictedPlugin(object):
         # tests that run after ours.
         ckan.plugins.unload('restricted')
 
-    def test_only_registered_users_can_access(self):
-        '''
-        Non registered users should not have access to and resources even if the package is public.
-        '''
-
-        owner = factories.User()
-        owner_org = factories.Organization(
-            users=[{'name': owner['id'], 'capacity': 'admin'}]
-        )
-        dataset = factories.Dataset(owner_org=owner_org['id'], private=False)
-        resource = factories.Resource(package_id=dataset['id'])
-        logic.check_access('package_show', {"user": None}, {'id': dataset['id']})
-        with assert_raises(logic.NotAuthorized):
-            logic.check_access('resource_show', {"user": None},  {'id': resource['id']})
-
     def test_basic_access(self):
-        '''
-        Checking that non owners can not access resources from private packages.
+        '''Normally organization admins can delete resources
+        Our plugin prevents this by blocking delete organization.
+
+        Ensure the delete button is not displayed (as only resource delete
+        is checked for showing this)
+
         '''
 
         owner = factories.User()
@@ -73,8 +62,12 @@ class TestRestrictedPlugin(object):
             logic.check_access('resource_show', {'user': access['name']}, {'id': resource['id']})
 
     def test_public_package_restricted_resource(self):
-        '''
-        Checking that non org users can not access resource from public package without permission
+        '''Normally organization admins can delete resources
+        Our plugin prevents this by blocking delete organization.
+
+        Ensure the delete button is not displayed (as only resource delete
+        is checked for showing this)
+
         '''
 
         owner = factories.User()
@@ -94,8 +87,12 @@ class TestRestrictedPlugin(object):
             logic.check_access('resource_show', {'user': access['name']}, {'id': resource['id']})
 
     def test_public_resource(self):
-        '''
-        Testing that all registered users can access public resources in public packages.
+        '''Normally organization admins can delete resources
+        Our plugin prevents this by blocking delete organization.
+
+        Ensure the delete button is not displayed (as only resource delete
+        is checked for showing this)
+
         '''
 
         owner = factories.User()
@@ -112,8 +109,11 @@ class TestRestrictedPlugin(object):
         assert logic.check_access('resource_show', {'user': access['name']}, {'id': resource['id']})
 
     def test_allow_users(self):
-        '''
-        Testing granting access to individual users.
+        '''Normally organization admins can delete resources
+        Our plugin prevents this by blocking delete organization.
+
+        Ensure the delete button is not displayed (as only resource delete
+        is checked for showing this)
 
         '''
 
@@ -134,8 +134,11 @@ class TestRestrictedPlugin(object):
             logic.check_access('resource_show', {'user': access2['name']}, {'id': resource['id']})
 
     def test_allow_organizations(self):
-        '''
-        Testing granting access to organisations.
+        '''Normally organization admins can delete resources
+        Our plugin prevents this by blocking delete organization.
+
+        Ensure the delete button is not displayed (as only resource delete
+        is checked for showing this)
 
         '''
 


### PR DESCRIPTION
In the early days of requirements analysis we decided that public datasets should only be visible to logged in users.  I have reason to believe that this has changed.  This pull reverts the feature.