### PR TITLE
Adx 342 user can display only resources he has access to

### DIFF
--- a/ckanext/restricted/action.py
+++ b/ckanext/restricted/action.py
@@ -157,7 +157,9 @@ def restricted_package_search(context, data_dict):
             restricted_package_search_result_list = []
             for package in value:
                 restricted_package_search_result_list.append(
-                    restricted_package_show(context, {'id': package.get('id'), 'hide_inaccessible_resources': hide_inaccessible_resources}))
+                    restricted_package_show(
+                        context, {'id': package.get('id'), 'hide_inaccessible_resources': hide_inaccessible_resources})
+                )
             restricted_package_search_result[key] = \
                 restricted_package_search_result_list
         else:

--- a/ckanext/restricted/action.py
+++ b/ckanext/restricted/action.py
@@ -90,6 +90,7 @@ def restricted_resource_view_list(context, data_dict):
 
 @side_effect_free
 def restricted_package_show(context, data_dict):
+    only_available = p.toolkit.asbool(data_dict.get('only_available', False))
 
     package_metadata = package_show(context, data_dict)
 
@@ -106,8 +107,12 @@ def restricted_package_show(context, data_dict):
 
     # restricted_package_metadata['resources'] = _restricted_resource_list_url(
     #     context, restricted_package_metadata.get('resources', []))
-    restricted_package_metadata['resources'] = _restricted_resource_list_hide_fields(
-        context, restricted_package_metadata.get('resources', []))
+    resources = restricted_package_metadata.get('resources', [])
+    if only_available:
+        resources = _restricted_resource_list_accessible_by_user(context, resources)
+        restricted_package_metadata['num_resources'] = len(resources)
+    resources = _restricted_resource_list_hide_fields(context, resources)
+    restricted_package_metadata['resources'] = resources
 
     return (restricted_package_metadata)
 
@@ -141,6 +146,7 @@ def restricted_resource_search(context, data_dict):
 
 @side_effect_free
 def restricted_package_search(context, data_dict):
+    only_available = p.toolkit.asbool(data_dict.pop('only_available', False))
     package_search_result = package_search(context, data_dict)
 
     restricted_package_search_result = {}
@@ -150,7 +156,7 @@ def restricted_package_search(context, data_dict):
             restricted_package_search_result_list = []
             for package in value:
                 restricted_package_search_result_list.append(
-                    restricted_package_show(context, {'id': package.get('id')}))
+                    restricted_package_show(context, {'id': package.get('id'), 'only_available': only_available}))
             restricted_package_search_result[key] = \
                 restricted_package_search_result_list
         else:

--- a/ckanext/restricted/action.py
+++ b/ckanext/restricted/action.py
@@ -146,6 +146,7 @@ def restricted_resource_search(context, data_dict):
 
 @side_effect_free
 def restricted_package_search(context, data_dict):
+    # pop the param as ckan package search action doesn't support any extra parameters
     hide_inaccessible_resources = p.toolkit.asbool(data_dict.pop('hide_inaccessible_resources', False))
     package_search_result = package_search(context, data_dict)
 

--- a/ckanext/restricted/action.py
+++ b/ckanext/restricted/action.py
@@ -90,7 +90,7 @@ def restricted_resource_view_list(context, data_dict):
 
 @side_effect_free
 def restricted_package_show(context, data_dict):
-    only_available = p.toolkit.asbool(data_dict.get('only_available', False))
+    hide_inaccessible_resources = p.toolkit.asbool(data_dict.get('hide_inaccessible_resources', False))
 
     package_metadata = package_show(context, data_dict)
 
@@ -108,7 +108,7 @@ def restricted_package_show(context, data_dict):
     # restricted_package_metadata['resources'] = _restricted_resource_list_url(
     #     context, restricted_package_metadata.get('resources', []))
     resources = restricted_package_metadata.get('resources', [])
-    if only_available:
+    if hide_inaccessible_resources:
         resources = _restricted_resource_list_accessible_by_user(context, resources)
         restricted_package_metadata['num_resources'] = len(resources)
     resources = _restricted_resource_list_hide_fields(context, resources)
@@ -131,11 +131,11 @@ def _restricted_resource_list_accessible_by_user(context, resource_list):
 
 @side_effect_free
 def restricted_resource_search(context, data_dict):
-    only_available = p.toolkit.asbool(data_dict.get('only_available', False))
+    hide_inaccessible_resources = p.toolkit.asbool(data_dict.get('hide_inaccessible_resources', False))
 
     resource_search_result = resource_search(context, data_dict)
     results = resource_search_result['results']
-    if only_available:
+    if hide_inaccessible_resources:
         results = _restricted_resource_list_accessible_by_user(context, results)
     results = _restricted_resource_list_hide_fields(context, results)
     count = len(results)
@@ -146,7 +146,7 @@ def restricted_resource_search(context, data_dict):
 
 @side_effect_free
 def restricted_package_search(context, data_dict):
-    only_available = p.toolkit.asbool(data_dict.pop('only_available', False))
+    hide_inaccessible_resources = p.toolkit.asbool(data_dict.pop('hide_inaccessible_resources', False))
     package_search_result = package_search(context, data_dict)
 
     restricted_package_search_result = {}
@@ -156,7 +156,7 @@ def restricted_package_search(context, data_dict):
             restricted_package_search_result_list = []
             for package in value:
                 restricted_package_search_result_list.append(
-                    restricted_package_show(context, {'id': package.get('id'), 'only_available': only_available}))
+                    restricted_package_show(context, {'id': package.get('id'), 'hide_inaccessible_resources': hide_inaccessible_resources}))
             restricted_package_search_result[key] = \
                 restricted_package_search_result_list
         else:

--- a/ckanext/restricted/tests/test_plugin.py
+++ b/ckanext/restricted/tests/test_plugin.py
@@ -1,6 +1,6 @@
 """Tests for plugin.py."""
 # encoding: utf-8
-
+from ckan.tests import helpers
 from nose.tools import assert_raises
 import ckan.model as model
 import ckan.plugins
@@ -8,12 +8,14 @@ import ckan.tests.factories as factories
 import ckan.logic as logic
 
 
-class TestExampleIAuthFunctionsPluginV6ParentAuthFunctions(object):
+
+class TestRestrictedPlugin(object):
     '''Tests for the ckanext.example_iauthfunctions.plugin module.
 
     Specifically tests that overriding parent auth functions will cause
     child auth functions to use the overridden version.
     '''
+
     @classmethod
     def setup_class(cls):
         '''Nose runs this method once to setup our test class.'''
@@ -125,7 +127,7 @@ class TestExampleIAuthFunctionsPluginV6ParentAuthFunctions(object):
 
         )
         dataset = factories.Dataset(owner_org=owner_org['id'], private=False)
-        restrict_string = '{"level": "restricted", "allowed_users":["%s"]}' % (access["name"], )
+        restrict_string = '{"level": "restricted", "allowed_users":["%s"]}' % (access["name"],)
         resource = factories.Resource(package_id=dataset['id'],
                                       restricted=restrict_string)
 
@@ -154,10 +156,145 @@ class TestExampleIAuthFunctionsPluginV6ParentAuthFunctions(object):
         )
 
         dataset = factories.Dataset(owner_org=owner_org['id'], private=False)
-        restrict_string = '{"level": "restricted", "allowed_organizations":["%s"]}' % (access_org["name"], )
+        restrict_string = '{"level": "restricted", "allowed_organizations":["%s"]}' % (access_org["name"],)
         resource = factories.Resource(package_id=dataset['id'],
                                       restricted=restrict_string)
 
         assert logic.check_access('resource_show', {'user': access['name']}, {'id': resource['id']})
         with assert_raises(logic.NotAuthorized):
             logic.check_access('resource_show', {'user': access2['name']}, {'id': resource['id']})
+
+    def _two_users_with_two_restricted_resources(self):
+        restrict_string = '{{"level": "restricted", "allowed_organizations":["{!s}"]}}'
+        user = factories.User()
+        user_org = factories.Organization(
+            users=[{'name': user['id'], 'capacity': 'admin'}]
+
+        )
+        user_dataset = factories.Dataset(user_org=user_org['id'], private=False)
+        user_resource = factories.Resource(package_id=user_dataset['id'],
+                                           name="user-resource",
+                                           restricted=restrict_string.format(user_org["name"]))
+        other = factories.User()
+        other_org = factories.Organization(users=[{'name': other['id'], 'capacity': 'admin'}])
+        other_dataset = factories.Dataset(other_org=other_org['id'], private=False)
+        other_resource = factories.Resource(package_id=other_dataset['id'],
+                                            name="other-resource",
+                                            restricted=restrict_string.format(other_org["name"]))
+        return user, user_resource, other, other_resource
+
+    def test_user_can_search_only_accessible_resources(self):
+        # given:
+        user, user_resource, other, other_resource = self._two_users_with_two_restricted_resources()
+        # when:
+        context = {
+            'ignore_auth': False,
+            'user': other['name']
+        }
+        resource_search = helpers.call_action(
+            'resource_search',
+            context,
+            query='name:resource',
+            hide_inaccessible_resources=True
+        )
+        # then:
+        assert resource_search['count'] == 1
+        assert len(resource_search['results']) == 1
+        assert resource_search['results'][0] == other_resource
+
+    def test_user_can_search_all_resources(self):
+        # given:
+        user, user_resource, other, other_resource = self._two_users_with_two_restricted_resources()
+        # when:
+        context = {
+            'ignore_auth': False,
+            'user': other['name']
+        }
+        resource_search = helpers.call_action(
+            'resource_search',
+            context,
+            query='name:resource'
+        )
+        # then:
+        assert resource_search['count'] == 2
+        for r in [user_resource, other_resource]:
+            assert r in resource_search['results']
+
+    def _two_users_one_package_two_resources_one_restricted(self):
+        user = factories.User()
+        other = factories.User()
+        organisation = factories.Organization(
+            users=[
+                {'name': user['id'], 'capacity': 'admin'}
+            ]
+
+        )
+        restrict_other = '{{"level": "restricted", "allowed_users":["{}"]}}'.format(other["name"])
+        restrict_org = '{{"level": "restricted", "allowed_organisations":["{}"]}}'.format(organisation["name"])
+        dataset = factories.Dataset(owner_org=organisation['id'], private=False)
+        other_resource = factories.Resource(package_id=dataset['id'],
+                                            name="other-resource",
+                                            restricted=restrict_other)
+        org_resource = factories.Resource(package_id=dataset['id'],
+                                          name="org-resource",
+                                          restricted=restrict_org)
+        return dataset, other, other_resource, org_resource
+
+    def test_user_can_see_only_accessible_resource_in_package_show(self):
+        # given:
+        dataset, other, other_resource, org_resource = self._two_users_one_package_two_resources_one_restricted()
+        # when:
+        context = {
+            'ignore_auth': False,
+            'user': other['name']
+        }
+        package_show = helpers.call_action(
+            'package_show',
+            context,
+            id=dataset['id'],
+            hide_inaccessible_resources=True
+        )
+        # then:
+        assert package_show['num_resources'] == 1
+        assert len(package_show['resources']) == 1
+        assert package_show['resources'][0]['id'] == other_resource['id']
+
+    def test_user_can_see_all_resource_in_package_show(self):
+        # given:
+        dataset, other, other_resource, org_resource = self._two_users_one_package_two_resources_one_restricted()
+        # when:
+        context = {
+            'ignore_auth': False,
+            'user': other['name']
+        }
+        package_show = helpers.call_action(
+            'package_show',
+            context,
+            id=dataset['id']
+        )
+        # then:
+        assert package_show['num_resources'] == 2
+        assert len(package_show['resources']) == 2
+        resources_ids = [x['id'] for x in package_show['resources']]
+        for r in [org_resource['id'], other_resource['id']]:
+            assert r in resources_ids
+
+    def test_user_can_see_only_accessible_resource_in_package_search(self):
+        # given:
+        dataset, other, other_resource, org_resource = self._two_users_one_package_two_resources_one_restricted()
+        # when:
+        context = {
+            'ignore_auth': False,
+            'user': other['name']
+        }
+        package_search = helpers.call_action(
+            'package_search',
+            context,
+            q=dataset['title'],
+            hide_inaccessible_resources=True
+        )
+        # then:
+        package = package_search['results'][0]
+        assert package['num_resources'] == 1
+        assert len(package['resources']) == 1
+        assert package['resources'][0]['id'] == other_resource['id']

--- a/ckanext/restricted/tests/test_plugin.py
+++ b/ckanext/restricted/tests/test_plugin.py
@@ -9,35 +9,14 @@ import ckan.logic as logic
 
 
 
-class TestRestrictedPlugin(object):
+class TestRestrictedPlugin(helpers.FunctionalTestBase):
     '''Tests for the ckanext.example_iauthfunctions.plugin module.
 
     Specifically tests that overriding parent auth functions will cause
     child auth functions to use the overridden version.
     '''
 
-    @classmethod
-    def setup_class(cls):
-        '''Nose runs this method once to setup our test class.'''
-        # Test code should use CKAN's plugins.load() function to load plugins
-        # to be tested.
-        ckan.plugins.load('restricted')
-
-    def teardown(self):
-        '''Nose runs this method after each test method in our test class.'''
-        # Rebuild CKAN's database after each test method, so that each test
-        # method runs with a clean slate.
-        model.repo.rebuild_db()
-
-    @classmethod
-    def teardown_class(cls):
-        '''Nose runs this method once after all the test methods in our class
-        have been run.
-
-        '''
-        # We have to unload the plugin we loaded, so it doesn't affect any
-        # tests that run after ours.
-        ckan.plugins.unload('restricted')
+    _load_plugins = ['restricted']
 
     def test_basic_access(self):
         '''Normally organization admins can delete resources

--- a/ckanext/restricted/tests/test_plugin.py
+++ b/ckanext/restricted/tests/test_plugin.py
@@ -2,16 +2,12 @@
 # encoding: utf-8
 from ckan.tests import helpers
 from nose.tools import assert_raises
-import ckan.model as model
-import ckan.plugins
 import ckan.tests.factories as factories
 import ckan.logic as logic
 
 
-
 class TestRestrictedPlugin(helpers.FunctionalTestBase):
     '''Tests for the ckanext.example_iauthfunctions.plugin module.
-
     Specifically tests that overriding parent auth functions will cause
     child auth functions to use the overridden version.
     '''


### PR DESCRIPTION
A new argument for `package_show` `package_search` and `resource_search` called `hide_inaccessible_resources` which removes resources the user can't download from response.
Example call would look like:
http://ckan:5000/api/3/action/resource_search?query=resource_type:programmatic-anc&hide_inaccessible_resources=true