### PR TITLE
Adx 353 Fix bug

### DIFF
--- a/ckanext/restricted/action.py
+++ b/ckanext/restricted/action.py
@@ -122,7 +122,7 @@ def _restricted_resource_list_accessible_by_user(context, resource_list):
     user_name = logic.restricted_get_username_from_context(context)
     for resource in resource_list:
         resource_dict = dict(resource)
-        package_dict = dict(id=resource_dict['package_id'])
+        package_dict = package_show(context, {'id': resource_dict['package_id']})
         if logic.restricted_check_user_resource_access(user_name, resource_dict, package_dict).get('success', False):
             restricted_resources_list.append(resource_dict)
 

--- a/ckanext/restricted/tests/test_plugin.py
+++ b/ckanext/restricted/tests/test_plugin.py
@@ -274,7 +274,7 @@ class TestRestrictedPlugin(helpers.FunctionalTestBase):
         assert len(package['resources']) == 1
         assert package['resources'][0]['id'] == other_resource['id']
 
-    def test_org_member_see_resources_package_search(self):
+    def test_org_member_see_only_accessible_resources_in_package_search(self):
         """
         A bug was flagged where the hide_inaccessible_resources param in
         the package_search action was causing resources only to be visible to
@@ -292,7 +292,6 @@ class TestRestrictedPlugin(helpers.FunctionalTestBase):
         dataset = factories.Dataset(owner_org=org['id'], private=False)
         resource = factories.Resource(
             package_id=dataset['id'],
-            name="resource",
             restricted=restricted
         )
         context = {

--- a/ckanext/restricted/tests/test_plugin.py
+++ b/ckanext/restricted/tests/test_plugin.py
@@ -273,3 +273,39 @@ class TestRestrictedPlugin(helpers.FunctionalTestBase):
         assert package['num_resources'] == 1
         assert len(package['resources']) == 1
         assert package['resources'][0]['id'] == other_resource['id']
+
+    def test_org_member_see_resources_package_search(self):
+        """
+        A bug was flagged where the hide_inaccessible_resources param in
+        the package_search action was causing resources only to be visible to
+        organisation "editors" and "admins" .  Organisation "members" with read
+        but not write privileges could not see the resources in a
+        package_search action.  This test checks that org members can see their
+        resources in a package_search action with
+        hide_inaccessible_resources=True.
+        """
+        user = factories.User()
+        org = factories.Organization(
+            users=[{'name': user['id'], 'capacity': 'member'}]
+        )
+        restricted = '{{"level": "restricted", "allowed_organisations":[], "allowed_users":[]}}'
+        dataset = factories.Dataset(owner_org=org['id'], private=False)
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            name="resource",
+            restricted=restricted
+        )
+        context = {
+            'ignore_auth': False,
+            'user': user['name']
+        }
+        package_search = helpers.call_action(
+            'package_search',
+            context,
+            q=dataset['title'],
+            hide_inaccessible_resources=True
+        )
+        package = package_search['results'][0]
+        assert package['num_resources'] == 1
+        assert len(package['resources']) == 1
+        assert package['resources'][0]['id'] == resource['id']


### PR DESCRIPTION
 The function `_restricted_resource_list_accessible_by_user()` was calling `logic.restricted_check_user_resource_access()` passing a fictionary of the form `{'id':<package_id}` as the `package_dict` param.  

The package_dict typically contains many fields, crucially in this case, the 'owner_org' param. 

This PR fixes the bug by sending the complete `package_dict` to `logic.restricted_check_user_resource_access()`. 