### PR TITLE
ADX-504 Override restricted auth with collaborators feature.

### DIFF
--- a/ckanext/restricted/logic.py
+++ b/ckanext/restricted/logic.py
@@ -74,6 +74,10 @@ def restricted_check_user_resource_access(user, resource_dict, package_dict):
                        {'id': package_dict['id']})
     restricted_dict = restricted_get_restricted_dict(resource_dict)
 
+    user_id = toolkit.get_action('user_show')({'ignore_auth': True}, {'id': user})['id']
+    if authz.user_is_collaborator_on_dataset(user_id, package_dict['id']):
+        return {'success': True}
+
     restricted_level = restricted_dict.get('level', 'restricted')
     allowed_users = restricted_dict.get('allowed_users', [])
     allowed_organizations = restricted_dict.get('allowed_organizations', [])

--- a/ckanext/restricted/tests/test_plugin.py
+++ b/ckanext/restricted/tests/test_plugin.py
@@ -282,6 +282,22 @@ class TestRestrictedPlugin(object):
         assert len(package['resources']) == 1
         assert package['resources'][0]['id'] == other_resource['id']
 
+    @pytest.mark.ckan_config(u'ckan.auth.allow_dataset_collaborators', 'true')
+    def test_collaborator_overrides_restricted_settings(self):
+        dataset, other, other_resource, org_resource = self._two_users_one_package_two_resources_one_restricted()
+        # when:
+        context = {
+            'ignore_auth': False,
+            'user': other['name']
+        }
+        with pytest.raises(logic.NotAuthorized):
+            logic.check_access('resource_show', context, {'id': org_resource['id']})
+        helpers.call_action(
+            'package_collaborator_create',
+            id=dataset['id'], user_id=other['name'], capacity='member')
+        assert logic.check_access('resource_show', context, {'id': org_resource['id']})
+        assert logic.check_access('resource_show', context, {'id': other_resource['id']})
+
     def test_org_member_see_only_accessible_resources_in_package_search(self):
         """
         A bug was flagged where the hide_inaccessible_resources param in

--- a/ckanext/restricted/tests/test_plugin.py
+++ b/ckanext/restricted/tests/test_plugin.py
@@ -285,16 +285,14 @@ class TestRestrictedPlugin(object):
     @pytest.mark.ckan_config(u'ckan.auth.allow_dataset_collaborators', 'true')
     def test_collaborator_overrides_restricted_settings(self):
         dataset, other, other_resource, org_resource = self._two_users_one_package_two_resources_one_restricted()
-        # when:
+        helpers.call_action(
+            'package_collaborator_create',
+            id=dataset['id'], user_id=other['name'], capacity='member'
+        )
         context = {
             'ignore_auth': False,
             'user': other['name']
         }
-        with pytest.raises(logic.NotAuthorized):
-            logic.check_access('resource_show', context, {'id': org_resource['id']})
-        helpers.call_action(
-            'package_collaborator_create',
-            id=dataset['id'], user_id=other['name'], capacity='member')
         assert logic.check_access('resource_show', context, {'id': org_resource['id']})
         assert logic.check_access('resource_show', context, {'id': other_resource['id']})
 


### PR DESCRIPTION
Test passes locally. 

Basically before going through restricted logic to check the user has access to read the resource, we first check if the user is a collaborator in any capacity, and if they are we return saying that the user is authorised.

Collaborators who are editors or higher already override the ckanext-restricted auth checks, but not members. This PR fixes that.  