### PR TITLE
ADX-530-fix-email-template-encoding

### DIFF
--- a/ckanext/restricted/controller.py
+++ b/ckanext/restricted/controller.py
@@ -23,8 +23,8 @@ except ImportError:
 import simplejson as json
 
 from logging import getLogger
-log = getLogger(__name__)
 
+log = getLogger(__name__)
 
 DataError = dictization_functions.DataError
 unflatten = dictization_functions.unflatten
@@ -33,6 +33,7 @@ render = base.render
 
 SEND_SUCCESS = True
 SEND_FAILED = False
+
 
 class RestrictedController(toolkit.BaseController):
 
@@ -103,8 +104,8 @@ class RestrictedController(toolkit.BaseController):
             ]
             # fetch users directly from db to get non-hashed emails
             dataset_org_admins = model.Session.query(model.User).filter(
-                    model.User.id.in_(dataset_org_admin_ids),
-                    model.User.email.isnot(None)
+                model.User.id.in_(dataset_org_admin_ids),
+                model.User.email.isnot(None)
             ).all()
             email_dict.update({
                 user.email: user.name

--- a/ckanext/restricted/controller.py
+++ b/ckanext/restricted/controller.py
@@ -48,17 +48,23 @@ class RestrictedController(toolkit.BaseController):
         success = False
         try:
 
-            resource_link = toolkit.url_for(
-                action='resource_read',
-                controller='package',
-                id=data.get('package_name'),
-                resource_id=data.get('resource_id'))
+            context = {
+                'model': model,
+                'session': model.Session,
+                'ignore_auth': True
+            }
+            dataset = toolkit.get_action('package_show')(
+                context, {'id': data.get('package_name')}
+            )
 
+            resource_link = toolkit.url_for(
+                '{}_resource.read'.format(dataset['type']),
+                id=dataset['name'],
+                resource_id=data.get('resource'))
             resource_edit_link = toolkit.url_for(
-                action='resource_edit',
-                controller='package',
-                id=data.get('package_name'),
-                resource_id=data.get('resource_id'))
+                '{}_resource.edit'.format(dataset['type']),
+                id=dataset['name'],
+                resource_id=data.get('resource'))
 
             extra_vars = {
                 'site_title': config.get('ckan.site_title'),
@@ -85,14 +91,6 @@ class RestrictedController(toolkit.BaseController):
                 data.get('maintainer_email'): extra_vars.get('maintainer_name'),
                 extra_vars.get('admin_email_to'): '{} Admin'.format(extra_vars.get('site_title'))}
 
-            context = {
-                'model': model,
-                'session': model.Session,
-                'ignore_auth': True
-            }
-            dataset = toolkit.get_action('package_show')(
-                context, {'id': data.get('package_name')}
-            )
             dataset_org = toolkit.get_action('organization_show')(
                 context, {'id': dataset['owner_org']}
             )

--- a/ckanext/restricted/templates/restricted/emails/restricted_access_request.txt
+++ b/ckanext/restricted/templates/restricted/emails/restricted_access_request.txt
@@ -1,13 +1,13 @@
 {% trans %}Dear{% endtrans %} {{ maintainer_name }},
 
 {% trans %}A user has requested access to your data in {{ site_title }}:{% endtrans %}
-* {% trans %}Resource:{% endtrans %} {{ resource_name }} ({{ resource_link }})
+* {% trans %}Resource:{% endtrans %} {{ resource_name }} ({{ resource_link|safe }})
 * {% trans %}Dataset:{% endtrans %} {{ package_name }}
 * {% trans %}User:{% endtrans %} {{ user_name }} ({{ user_email }})
 * {% trans %}Message:{% endtrans %} {{ message }}
 
 {% trans %}You can allow this user to access you resource by adding {{ user_id }} to the list of allowed users.{% endtrans %}
-{% trans %}If you have editor rights, you can edit the resource in this link: {{ resource_edit_link }}.{% endtrans %}
+{% trans %}If you have editor rights, you can edit the resource in this link{% endtrans %}: {{ resource_edit_link|safe }}.
 {% trans %}If you have any questions about how to proceed with this request, please contact the {{ site_title }} support at {{ admin_email_to }}.{% endtrans %}
 
 {% trans %}Best regards,{% endtrans %}

--- a/ckanext/restricted/templates/restricted/emails/restricted_user_allowed.txt
+++ b/ckanext/restricted/templates/restricted/emails/restricted_user_allowed.txt
@@ -3,7 +3,7 @@
 {% trans %}You have requested access on {{ site_title }} to the resource: {{ resource_name }}.{% endtrans %}
 {% trans %}The contact person of the package has granted you access.{% endtrans %}
 
-{% trans %}Please click the following link: {{ resource_link }}{% endtrans %}
+{% trans %}Please click the following link{% endtrans %}: {{ resource_link|safe }}
 
 {% trans %}Best regards,{% endtrans %}
 {% trans %}{{ site_title }} Administrator{% endtrans %}

--- a/ckanext/restricted/tests/test_access_request.py
+++ b/ckanext/restricted/tests/test_access_request.py
@@ -124,3 +124,53 @@ class TestAccessRequest(object):
         ]
         assert editor['email'] not in email_recipients, 'Only org admins should be emailed, not editors'
         assert member['email'] not in email_recipients, 'Only org admins should be emailed, not members'
+
+    @mock.patch('ckan.lib.mailer.mail_recipient')
+    def test_org_admin_is_emailed_if_no_maintaner_on_request_access(self, mocked_mail_recipient, app):
+
+        admin = factories.User(email='admin_1@example.com')
+        owner_org = factories.Organization(
+            users=[
+                {'name': admin['id'], 'capacity': 'admin'},
+            ]
+        )
+
+        dataset = factories.Dataset(
+            owner_org=owner_org['id'],
+            name='name',
+            private=False,
+            user=admin
+        )
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            name='name',
+            restricted='{"level": "public"}'
+        )
+
+        # stranger requests access to dataset
+        stranger = factories.User(email='stranger@example.com')
+        request_access_url = url_for(
+            controller='ckanext.restricted.controller:RestrictedController',
+            action='restricted_request_access_form',
+            package_id=dataset['id'],
+            resource_id=resource['id']
+        )
+        response = app.get(
+            url=request_access_url,
+            query_string={
+                'package_name': dataset['id'],
+                'resource': resource['id'],
+                'message': 'aaaa',
+                'maintainer_email': '',
+                'save': 1
+            },
+            extra_environ={'REMOTE_USER': stranger['name']}
+        )
+        assert response.status_code == 200
+
+        mocked_mail_recipient.assert_called()
+        email_recipients = [
+            x[0][1]  # recipient_email
+            for x in mocked_mail_recipient.call_args_list
+        ]
+        assert admin['email'] in email_recipients, 'Only org admins should be emailed, not members'

--- a/ckanext/restricted/tests/test_access_request_email_templates.py
+++ b/ckanext/restricted/tests/test_access_request_email_templates.py
@@ -1,0 +1,64 @@
+# encoding: utf-8
+import ckan.tests.factories as factories
+from ckan.lib.helpers import url_for
+import pytest
+import mock
+
+
+@pytest.mark.usefixtures(u'clean_db')
+@pytest.mark.usefixtures(u'clean_index')
+@pytest.mark.ckan_config(u'ckan.plugins', u'restricted image_view recline_view')
+@pytest.mark.usefixtures(u'with_plugins')
+@pytest.mark.usefixtures(u'with_request_context')
+class TestAccessRequestEmailTemplate(object):
+
+    @mock.patch('ckan.lib.mailer.mail_recipient')
+    def test_restricted_access_request_template_encoding(self, mocked_mail_recipient, app):
+
+        admin_1 = factories.User()
+        admin_2 = factories.User()
+        owner_org = factories.Organization(
+            users=[
+                {'name': admin_1['id'], 'capacity': 'admin'},
+                {'name': admin_2['id'], 'capacity': 'admin'},
+            ]
+        )
+
+        # admin_1 creates a dataset
+        dataset = factories.Dataset(
+            owner_org=owner_org['id'],
+            name='name',
+            private=False,
+            user=admin_1
+        )
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            name='name',
+            restricted='{"level": "public"}'
+        )
+
+        # stranger requests access to dataset
+        stranger = factories.User()
+        request_access_url = url_for(
+            controller='ckanext.restricted.controller:RestrictedController',
+            action='restricted_request_access_form',
+            package_id=dataset['id'],
+            resource_id=resource['id']
+        )
+        response = app.get(
+            url=request_access_url,
+            query_string={
+                'package_name': dataset['id'],
+                'resource': resource['id'],
+                'message': 'aaaa',
+                'maintainer_email': '',
+                'save': 1
+            },
+            extra_environ={'REMOTE_USER': stranger['name']}
+        )
+        assert response.status_code == 200
+
+        mocked_mail_recipient.assert_called()
+        first_email = mocked_mail_recipient.call_args_list[0]
+        email_body = first_email[0][3]        
+        assert '&amp;' not in email_body

--- a/ckanext/restricted/tests/test_access_request_email_templates.py
+++ b/ckanext/restricted/tests/test_access_request_email_templates.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 import ckan.tests.factories as factories
 from ckan.lib.helpers import url_for
+import ckan.plugins.toolkit as toolkit
 import pytest
 import mock
 
@@ -11,6 +12,61 @@ import mock
 @pytest.mark.usefixtures(u'with_plugins')
 @pytest.mark.usefixtures(u'with_request_context')
 class TestAccessRequestEmailTemplate(object):
+
+    @mock.patch('ckan.lib.mailer.mail_recipient')
+    def test_restricted_access_request_template_vars(self, mocked_mail_recipient, app):
+
+        admin_1 = factories.User()
+        admin_2 = factories.User()
+        owner_org = factories.Organization(
+            users=[
+                {'name': admin_1['id'], 'capacity': 'admin'},
+                {'name': admin_2['id'], 'capacity': 'admin'},
+            ]
+        )
+
+        # admin_1 creates a dataset
+        dataset = factories.Dataset(
+            owner_org=owner_org['id'],
+            name='dataset-name',
+            private=False,
+            user=admin_1
+        )
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            name='resource-name',
+            restricted='{"level": "public"}'
+        )
+
+        # stranger requests access to dataset
+        stranger = factories.User()
+        request_access_url = url_for(
+            controller='ckanext.restricted.controller:RestrictedController',
+            action='restricted_request_access_form',
+            package_id=dataset['id'],
+            resource_id=resource['id']
+        )
+        response = app.get(
+            url=request_access_url,
+            query_string={
+                'package_name': dataset['id'],
+                'resource': resource['id'],
+                'message': 'aaaa',
+                'maintainer_email': '',
+                'save': 1
+            },
+            extra_environ={'REMOTE_USER': stranger['name']}
+        )
+        assert response.status_code == 200
+        mocked_mail_recipient.assert_called()
+        first_email = mocked_mail_recipient.call_args_list[0]
+        email_body = first_email[0][3]
+
+        resource_edit_link = toolkit.url_for(
+            '{}_resource.edit'.format(dataset['type']),
+            id=dataset['name'],
+            resource_id=resource['id'])
+        assert resource_edit_link in email_body
 
     @mock.patch('ckan.lib.mailer.mail_recipient')
     def test_restricted_access_request_template_encoding(self, mocked_mail_recipient, app):
@@ -60,5 +116,5 @@ class TestAccessRequestEmailTemplate(object):
 
         mocked_mail_recipient.assert_called()
         first_email = mocked_mail_recipient.call_args_list[0]
-        email_body = first_email[0][3]        
+        email_body = first_email[0][3]
         assert '&amp;' not in email_body

--- a/ckanext/restricted/tests/test_access_request_email_templates.py
+++ b/ckanext/restricted/tests/test_access_request_email_templates.py
@@ -40,18 +40,17 @@ class TestAccessRequestEmailTemplate(object):
 
         # stranger requests access to dataset
         stranger = factories.User()
+
         request_access_url = url_for(
             controller='ckanext.restricted.controller:RestrictedController',
             action='restricted_request_access_form',
-            package_id=dataset['id'],
+            package_id=dataset['name'],
             resource_id=resource['id']
         )
         response = app.get(
             url=request_access_url,
             query_string={
-                'package_name': dataset['id'],
-                'resource': resource['id'],
-                'message': 'aaaa',
+                'message': 'give me access!',
                 'maintainer_email': '',
                 'save': 1
             },


### PR DESCRIPTION
# Problem
- The view/edit resource urls are wrong
- Some links in emails are having their queryparam `&` symbols encoded into `&amp;` which breaks the link
- We're also accidentally wrapping links within `{% trans %}{% endtrans %}` which also breaks the link

# Solution
- Fix view/edit resource urls
- Add `{{ resource_edit_link|safe }}` so characters are not encoded by jinja2
- Fix issues with having links wrongly translated