### PR TITLE
Adx 548 fix request org flow

### DIFF
--- a/ckanext/restricted/controller.py
+++ b/ckanext/restricted/controller.py
@@ -307,7 +307,7 @@ class RestrictedController(toolkit.BaseController):
 
         return render(
             'restricted/restricted_request_organization_result.html',
-            extra_vars={'data': data_dict, 'success': success}
+            extra_vars={'data': data_dict, 'pkg_dict': {}, 'success': success}
         )
 
     def _send_organization_request_mail(self, data):
@@ -399,7 +399,7 @@ class RestrictedController(toolkit.BaseController):
         data['user_email'] = user.get('email', '')
 
         extra_vars = {
-            'data': data, 'group_type': "organization",
+            'data': data, 'group_type': "organization", 'pkg_dict': {},
             'errors': errors, 'error_summary': error_summary
         }
         return render(

--- a/ckanext/restricted/controller.py
+++ b/ckanext/restricted/controller.py
@@ -346,7 +346,7 @@ class RestrictedController(toolkit.BaseController):
 
             # CC doesn't work and mailer cannot send to multiple addresses
             for email, name in email_dict.iteritems():
-                mailer.mail_recipient(name, email, subject, body, headers)
+                mailer.mail_recipient(name, email, subject, body, headers=headers)
 
             # Special copy for the user (no links)
             email = data.get('user_email')
@@ -361,7 +361,7 @@ class RestrictedController(toolkit.BaseController):
             ).format(body.replace("\n", "\n >> "))
 
             mailer.mail_recipient(
-                name, email, 'Fwd: ' + subject, body_user, headers)
+                name, email, 'Fwd: ' + subject, body_user, headers=headers)
             success = True
 
         except mailer.MailerException as mailer_exception:

--- a/ckanext/restricted/controller.py
+++ b/ckanext/restricted/controller.py
@@ -399,7 +399,7 @@ class RestrictedController(toolkit.BaseController):
         data['user_email'] = user.get('email', '')
 
         extra_vars = {
-            'data': data, 'group_type': "organization", 'pkg_dict': {},
+            'data': data, 'group_type': "organization",
             'errors': errors, 'error_summary': error_summary
         }
         return render(

--- a/ckanext/restricted/templates/restricted/restricted_request_access_base.html
+++ b/ckanext/restricted/templates/restricted/restricted_request_access_base.html
@@ -1,4 +1,3 @@
-{% set pkg_dict = pkg_dict or {} %}
 {% extends "package/base.html" %}
 
 {% block subtitle %}{{ _('Request Access') }}{% endblock %}

--- a/ckanext/restricted/templates/restricted/restricted_request_access_base.html
+++ b/ckanext/restricted/templates/restricted/restricted_request_access_base.html
@@ -1,3 +1,4 @@
+{% set pkg_dict = pkg_dict or {} %}
 {% extends "package/base.html" %}
 
 {% block subtitle %}{{ _('Request Access') }}{% endblock %}


### PR DESCRIPTION
## Requesting an Organisation throws an error

The issue is that the mailer function looks like:
```
def mail_recipient(
    recipient_name, recipient_email, subject,
    body, body_html=None, headers={}
):
```

and our restricted code passing in:
```
mailer.mail_recipient(name, email, subject, body, headers)
```
Which is wrong as `headers` was being parsed into the `body_html` arg
This is now fixed by setting `headers=headers`


## Org requested page throws error
- Once you've requested an organisation, the next page fails
- This is due to `restricted_request_organization_result.html` which extends `restricted_request_access_base.html` which then extends `package/base.html`
- The `package/base.html` [template expects `pkg_dict` to be defined](https://github.com/ckan/ckan/blob/bb272bfc7167b35cbff8ce48ed815dd4e23597ba/ckan/templates/package/base.html#L3) however one isn't present in our view
