### PR TITLE
ADX-550 Fixed tests

### DIFF
--- a/ckanext/restricted/tests/test_access_request.py
+++ b/ckanext/restricted/tests/test_access_request.py
@@ -49,8 +49,8 @@ class TestAccessRequest(object):
         response = app.get(
             url=request_access_url,
             query_string={
-                'package_name': dataset['id'],
-                'resource': resource['id'],
+                'package_name': dataset['name'],
+                'resource_id': resource['id'],
                 'message': 'aaaa',
                 'maintainer_email': maintainer_email,
                 'save': 1
@@ -107,8 +107,8 @@ class TestAccessRequest(object):
         response = app.get(
             url=request_access_url,
             query_string={
-                'package_name': dataset['id'],
-                'resource': resource['id'],
+                'package_name': dataset['name'],
+                'resource_id': resource['id'],
                 'message': 'aaaa',
                 'maintainer_email': maintainer_email,
                 'save': 1
@@ -158,8 +158,8 @@ class TestAccessRequest(object):
         response = app.get(
             url=request_access_url,
             query_string={
-                'package_name': dataset['id'],
-                'resource': resource['id'],
+                'package_name': dataset['name'],
+                'resource_id': resource['id'],
                 'message': 'aaaa',
                 'maintainer_email': '',
                 'save': 1


### PR DESCRIPTION
# Problem
Tests were failing with:
```
5 failed, 13 passed, 904 warnings in 26.60 seconds
```

# Solution
- Stopped wrongly sending `resource` rather than `resource_id` as a param (i'm sure we talked about this before!)
- Started setting `package_name` param to `dataset['name']` rather than `dataset['id']` to have the correct url display in the email body to admins
```
 18 passed, 922 warnings in 27.71 seconds 
```