### PR TITLE
ADX-640 Remove redundant auth check creating 75% speed incease

### DIFF
--- a/ckanext/restricted/action.py
+++ b/ckanext/restricted/action.py
@@ -206,11 +206,6 @@ def _restricted_resource_list_hide_fields(context, resource_list):
         # get the restricted fields
         restricted_dict = logic.restricted_get_restricted_dict(restricted_resource)
 
-        # hide fields to unauthorized users
-        auth.restricted_resource_show(
-            context, {'id': resource.get('id'), 'resource': resource}
-        ).get('success', False)
-
         # hide other fields in restricted to everyone but dataset owner(s)
         if not authz.is_authorized(
                 'package_update', context, {'id': resource.get('package_id')}


### PR DESCRIPTION
Maybe I'm being stupid, but there is a line of code here that appears to do nothing and is slowing `package_search` actions down by 75%. 

Removing it breaks no tests and does not change UI behaviour in any way that I can see.

The purpose of the line of code is to check whether the user should be allowed to view a given resource.  However nothing is done with the output - it is just ignored. 

I wonder whether the intended purpose was originally to completely hide any resources that the user shouldn't have access to - in a similar way to the work that @tomeksabala has done with the `hide_inaccessible_resources` flag. If this is the intended purpose, it simply doesn't work. 

My local `package_search` request time drops from approx 1.85 to 0.35 seconds just by removing this single line... so we need to know why it should be there!