### PR TITLE
Adx 640 restricted delays

### DIFF
--- a/ckanext/restricted/action.py
+++ b/ckanext/restricted/action.py
@@ -120,7 +120,14 @@ def _restricted_resource_list_accessible_by_user(context, resource_list, package
         resource_dict = dict(resource)
         if not package_dict:
             package_dict = package_show(context, {'id': resource_dict['package_id']})
-        if logic.restricted_check_user_resource_access(user_name, resource_dict, package_dict, user_obj=user_obj, pkg_show=False).get('success', False):
+        auth_result = logic.restricted_check_user_resource_access(
+            user_name,
+            resource_dict,
+            package_dict,
+            user_obj=user_obj,
+            pkg_show=False
+        )
+        if auth_result.get('success', False):
             restricted_resources_list.append(resource_dict)
 
     return restricted_resources_list

--- a/ckanext/restricted/action.py
+++ b/ckanext/restricted/action.py
@@ -114,35 +114,22 @@ def _restricted_resource_list_accessible_by_user(context, resource_list, package
     restricted_resources_list = []
     user_name = logic.restricted_get_username_from_context(context)
     user_obj = context.get('auth_user_obj')
-    if user_obj:
-        user_obj.org_dict = _get_org_dict(user_name)
     for resource in resource_list:
         resource_dict = dict(resource)
         if not package_dict:
             package_dict = package_show(context, {'id': resource_dict['package_id']})
-        auth_result = logic.restricted_check_user_resource_access(
+        user_has_resource_access = logic.restricted_check_user_resource_access(
             user_name,
             resource_dict,
             package_dict,
             user_obj=user_obj,
-            pkg_show=False
-        )
-        if auth_result.get('success', False):
+            check_access_package_show=False,
+            user_organization_dict=logic.get_organization_dict(user_name)
+        ).get('success', False)
+        if user_has_resource_access:
             restricted_resources_list.append(resource_dict)
-
     return restricted_resources_list
 
-
-def _get_org_dict(user_name):
-    user_organization_dict = {}
-    context = {'user': user_name}
-    data_dict = {'permission': 'read'}
-    for org in ckan.logic.get_action('organization_list_for_user')(context, data_dict):
-        name = org.get('name', '')
-        id = org.get('id', '')
-        if name and id:
-            user_organization_dict[id] = name
-    return user_organization_dict
 
 
 @toolkit.side_effect_free

--- a/ckanext/restricted/action.py
+++ b/ckanext/restricted/action.py
@@ -114,14 +114,28 @@ def _restricted_resource_list_accessible_by_user(context, resource_list, package
     restricted_resources_list = []
     user_name = logic.restricted_get_username_from_context(context)
     user_obj = context.get('auth_user_obj')
+    if user_obj:
+        user_obj.org_dict = _get_org_dict(user_name)
     for resource in resource_list:
         resource_dict = dict(resource)
         if not package_dict:
             package_dict = package_show(context, {'id': resource_dict['package_id']})
-        if logic.restricted_check_user_resource_access(user_name, resource_dict, package_dict, user_obj=user_obj).get('success', False):
+        if logic.restricted_check_user_resource_access(user_name, resource_dict, package_dict, user_obj=user_obj, pkg_show=False).get('success', False):
             restricted_resources_list.append(resource_dict)
 
     return restricted_resources_list
+
+
+def _get_org_dict(user_name):
+    user_organization_dict = {}
+    context = {'user': user_name}
+    data_dict = {'permission': 'read'}
+    for org in ckan.logic.get_action('organization_list_for_user')(context, data_dict):
+        name = org.get('name', '')
+        id = org.get('id', '')
+        if name and id:
+            user_organization_dict[id] = name
+    return user_organization_dict
 
 
 @toolkit.side_effect_free

--- a/ckanext/restricted/logic.py
+++ b/ckanext/restricted/logic.py
@@ -68,10 +68,12 @@ def restricted_get_restricted_dict(resource_dict):
     return restricted_dict
 
 
-def restricted_check_user_resource_access(user, resource_dict, package_dict, user_obj=None):
+def restricted_check_user_resource_access(user, resource_dict, package_dict, user_obj=None, pkg_show=True):
     # Check access to package
-    logic.check_access('package_show', {'user': user},
-                       {'id': package_dict['id']})
+    if pkg_show:
+        logic.check_access('package_show', {'user': user},
+                           {'id': package_dict['id']})
+
     restricted_dict = restricted_get_restricted_dict(resource_dict)
 
     if user:
@@ -98,16 +100,17 @@ def restricted_check_user_resource_access(user, resource_dict, package_dict, use
         return {'success': True}
 
     # Get organization list
-    user_organization_dict = {}
+    user_organization_dict = getattr(user_obj, 'org_dict', {})
 
     context = {'user': user}
     data_dict = {'permission': 'read'}
 
-    for org in logic.get_action('organization_list_for_user')(context, data_dict):
-        name = org.get('name', '')
-        id = org.get('id', '')
-        if name and id:
-            user_organization_dict[id] = name
+    if not user_organization_dict:
+        for org in logic.get_action('organization_list_for_user')(context, data_dict):
+            name = org.get('name', '')
+            id = org.get('id', '')
+            if name and id:
+                user_organization_dict[id] = name
 
     pkg_organization_id = package_dict.get('owner_org', '')
     # Same Organization Members

--- a/ckanext/restricted/logic.py
+++ b/ckanext/restricted/logic.py
@@ -68,9 +68,11 @@ def restricted_get_restricted_dict(resource_dict):
     return restricted_dict
 
 
-def restricted_check_user_resource_access(user, resource_dict, package_dict, user_obj=None, pkg_show=True):
+def restricted_check_user_resource_access(user, resource_dict, package_dict,
+                                          user_obj=None, check_access_package_show=True,
+                                          user_organization_dict={}):
     # Check access to package
-    if pkg_show:
+    if check_access_package_show:
         logic.check_access('package_show', {'user': user},
                            {'id': package_dict['id']})
 
@@ -99,18 +101,8 @@ def restricted_check_user_resource_access(user, resource_dict, package_dict, use
     if user in allowed_users:
         return {'success': True}
 
-    # Get organization list
-    user_organization_dict = getattr(user_obj, 'org_dict', {})
-
-    context = {'user': user}
-    data_dict = {'permission': 'read'}
-
     if not user_organization_dict:
-        for org in logic.get_action('organization_list_for_user')(context, data_dict):
-            name = org.get('name', '')
-            id = org.get('id', '')
-            if name and id:
-                user_organization_dict[id] = name
+        user_organization_dict = get_organization_dict(user_id)
 
     pkg_organization_id = package_dict.get('owner_org', '')
     # Same Organization Members
@@ -120,6 +112,18 @@ def restricted_check_user_resource_access(user, resource_dict, package_dict, use
     return {
         'success': False,
         'msg': ('Resource access restricted')}
+
+
+def get_organization_dict(user_name):
+    user_organization_dict = {}
+    context = {'user': user_name}
+    data_dict = {'permission': 'read'}
+    for org in logic.get_action('organization_list_for_user')(context, data_dict):
+        name = org.get('name', '')
+        id = org.get('id', '')
+        if name and id:
+            user_organization_dict[id] = name
+    return user_organization_dict
 
 
 def restricted_mail_allowed_user(user_id, resource):
@@ -135,7 +139,6 @@ def restricted_mail_allowed_user(user_id, resource):
         resource_name = resource.get('name', resource['id'])
 
         # maybe check user[activity_streams_email_notifications]==True
-
         mail_body = restricted_allowed_user_mail_body(user, resource)
         mail_subject = _('Access granted to resource {}').format(resource_name)
 


### PR DESCRIPTION
The hide_inaccessible_resources flag is still causing significant delays in package_search requests. 

I figured that in these cases there are two actions that are repeated for every resource when in practise they only need to be done once per request or package. 

- checking the user can access package_show only needs to be done once per package, and in actual fact this is done when fetching the package dict already, higher up the code stack.
- Checking the users org list is repeated for every resource, this only needs to be done once for the request.


With these two changes package_search requests are reduced to 25% of the time that they previously took. 

I'm concerned about a software engineer coming along later and calling `_restricted_resource_list_accessible_by_user` with the package_dict argument populated without having authed to check the user can see package_show. (e.g.t hey may have fetched the package_dict straight from the model). However adding in a package show check adds 0.12 seconds per package in the search result (5 s over the existing 50 packages in CKAN). 