### PR TITLE
ADX-752 Only set default restricted values if creating a new resource.

### DIFF
--- a/ckanext/restricted/templates/scheming/form_snippets/restricted_fields.html
+++ b/ckanext/restricted/templates/scheming/form_snippets/restricted_fields.html
@@ -7,11 +7,11 @@
 
 {%- set options=[] -%}
 
-{%- if data.get('id') -%}
-  {% set restricted = h.restricted_json_loads(data.get("restricted")) %}
-{%- else -%}
+{% if data.get('id') %}
+  {%- set restricted = h.restricted_json_loads(data.get("restricted")) -%}
+{% else %}
   {%- set restricted = h.restricted_json_loads(field.get("default_restricted")) -%}
-{%- endif -%}
+{% endif %}
 
 {%- for c in h.scheming_field_choices(field) -%}
   {%- if not form_restrict_choices_to or c.value in form_restrict_choices_to -%}


### PR DESCRIPTION
This PR ensures that the default restricted values are only populated when creating a new resource.

If an existing resource is missing restricted data, the restricted fields should be left empty in the resource_edit UI.
If an existing resource already has restricted data, this should be pre-populated in the resource_edit UI.
If a new resource is being created, the default restricted settings should be proposed.

Requires: https://github.com/fjelltopp/ckanext-unaids/pull/159