### PR TITLE
ADX-795 email links

### DIFF
--- a/ckanext/restricted/i18n/fr/LC_MESSAGES/ckanext-restricted.po
+++ b/ckanext/restricted/i18n/fr/LC_MESSAGES/ckanext-restricted.po
@@ -496,9 +496,10 @@ msgid "The contact person of the package has granted you access."
 msgstr "La personne contactée a autorisé votre accès."
 
 #: ckanext/restricted/templates/restricted/emails/restricted_user_allowed.txt:6
-#, python-format
-msgid "Please click the following link: %(resource_link)s"
-msgstr "Vous pouvez accéder à la ressource via ce lien : %(resource_link)s"
+#, fuzzy, python-format
+#| msgid "Please click the following link"
+msgid "Please click the following link to access the resource"
+msgstr "Vous pouvez accéder à la ressource via ce lien"
 
 #: ckanext/restricted/templates/restricted/emails/restricted_user_registered.txt:3
 msgid "A new user registered, please review the information:"

--- a/ckanext/restricted/logic.py
+++ b/ckanext/restricted/logic.py
@@ -157,9 +157,10 @@ def restricted_mail_allowed_user(user_id, resource):
 
 def restricted_allowed_user_mail_body(user, resource):
     resource_link = toolkit.url_for(
-        controller='package', action='resource_read',
-        id=resource.get('package_id'), resource_id=resource.get('id'))
-
+        "resource.read",
+        id=resource.get('package_id'),
+        resource_id=resource.get('id')
+    )
     extra_vars = {
         'site_title': config.get('ckan.site_title'),
         'site_url': config.get('ckan.site_url'),

--- a/ckanext/restricted/templates/restricted/emails/restricted_user_allowed.txt
+++ b/ckanext/restricted/templates/restricted/emails/restricted_user_allowed.txt
@@ -3,7 +3,7 @@
 {% trans %}You have requested access on {{ site_title }} to the resource: {{ resource_name }}.{% endtrans %}
 {% trans %}The contact person of the package has granted you access.{% endtrans %}
 
-{% trans %}Please click the following link{% endtrans %}: {{ resource_link|safe }}
+{% trans %}Please click the following link to access the resource{% endtrans %}: {{ resource_link|safe }}
 
 {% trans %}Best regards,{% endtrans %}
 {% trans %}{{ site_title }} Administrator{% endtrans %}
@@ -12,4 +12,3 @@
 {% trans %}This is an automatically generated e-mail, please do not reply to it.{% endtrans %}
 
 {% trans %}Message sent from {{ site_title }} ({{ site_url }}){% endtrans %}
-

--- a/ckanext/restricted/tests/test_allowed_user_email_templates.py
+++ b/ckanext/restricted/tests/test_allowed_user_email_templates.py
@@ -17,8 +17,6 @@ class TestAllowedUserEmail(object):
         owner_org = factories.Organization(
             users=[{'name': admin['id'], 'capacity': 'admin'}]
         )
-
-        # admin_1 creates a dataset
         dataset = factories.Dataset(
             owner_org=owner_org['id'],
             name='dataset-name',
@@ -30,7 +28,6 @@ class TestAllowedUserEmail(object):
             name='resource-name',
             restricted='{"level": "public"}'
         )
-
         stranger = factories.User(email='stranger@example.com')
         result = restricted_allowed_user_mail_body(stranger, resource)
         expected_resource_link = "{}/dataset/{}/resource/{}".format(

--- a/ckanext/restricted/tests/test_allowed_user_email_templates.py
+++ b/ckanext/restricted/tests/test_allowed_user_email_templates.py
@@ -30,10 +30,10 @@ class TestAllowedUserEmail(object):
         )
         stranger = factories.User(email='stranger@example.com')
         result = restricted_allowed_user_mail_body(stranger, resource)
-        expected_resource_link = "{}/dataset/{}/resource/{}".format(
-            toolkit.config.get('ckan.site_url'),
-            dataset['id'],
-            resource['id']
+        expected_resource_link = toolkit.url_for(
+            "resource.read",
+            id=resource.get('package_id'),
+            resource_id=resource.get('id')
         )
         assert stranger['fullname'] in result
         assert expected_resource_link in result

--- a/ckanext/restricted/tests/test_allowed_user_email_templates.py
+++ b/ckanext/restricted/tests/test_allowed_user_email_templates.py
@@ -1,0 +1,42 @@
+# encoding: utf-8
+from ckanext.restricted.logic import restricted_allowed_user_mail_body
+import ckan.tests.factories as factories
+import ckan.plugins.toolkit as toolkit
+import pytest
+
+
+@pytest.mark.usefixtures(u'clean_db')
+@pytest.mark.usefixtures(u'clean_index')
+@pytest.mark.ckan_config(u'ckan.plugins', u'restricted')
+@pytest.mark.usefixtures(u'with_plugins')
+@pytest.mark.usefixtures(u'with_request_context')
+class TestAllowedUserEmail(object):
+
+    def test_restricted_allowed_user_mail_body(self):
+        admin = factories.User(name='admin')
+        owner_org = factories.Organization(
+            users=[{'name': admin['id'], 'capacity': 'admin'}]
+        )
+
+        # admin_1 creates a dataset
+        dataset = factories.Dataset(
+            owner_org=owner_org['id'],
+            name='dataset-name',
+            private=False,
+            user=admin
+        )
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            name='resource-name',
+            restricted='{"level": "public"}'
+        )
+
+        stranger = factories.User(email='stranger@example.com')
+        result = restricted_allowed_user_mail_body(stranger, resource)
+        expected_resource_link = "{}/dataset/{}/resource/{}".format(
+            toolkit.config.get('ckan.site_url'),
+            dataset['id'],
+            resource['id']
+        )
+        assert stranger['fullname'] in result
+        assert expected_resource_link in result


### PR DESCRIPTION
Our "access granted" emails had an old pylons style link it them.  

This fixes the issue.

Issue reported through the bug report form.

We should consider redirecting from the old URL to the new URL as well.