### PR TITLE
ADX-798 Cleanup debug logs

### DIFF
--- a/ckanext/restricted/action.py
+++ b/ckanext/restricted/action.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 import six
 
 import ckan.authz as authz
-import ckan.logic.auth as logic_auth
 from ckan import model
 from ckan.common import _
 
@@ -111,7 +110,7 @@ def restricted_package_show(context, data_dict, package_metadata=None):
         context['package'] = pkg
 
     if debug_logging:
-        debug_log.debug(u"{} restricted_package_show for package {}".format(
+        debug_log.debug("{} restricted_package_show for package {}".format(
             debug_request_id,
             package_metadata.get('name')
         ))
@@ -119,45 +118,12 @@ def restricted_package_show(context, data_dict, package_metadata=None):
     # Ensure user who can edit can see the resource
     if authz.is_authorized(
             'package_update', context, package_metadata).get('success', False):
-
         if debug_logging:
             debug_log.debug(
-                u"{} restricted_package_show granted - user authorised to edit dataset".format(
+                "{} restricted_package_show granted - user authorised to edit dataset".format(
                     debug_request_id
                 )
             )
-
-            package = logic_auth.get_package_object(context, package_metadata)
-            user = context.get('user')
-            user_obj = context['model'].User.get(user)
-            if package.owner_org:
-                owner_org_editor = authz.has_user_permission_for_group_or_org(
-                    package.owner_org, user, 'update_dataset'
-                )
-                collaborator = authz.user_is_collaborator_on_dataset(
-                    user_obj.id, package.id, ['admin', 'editor']
-                )
-                if owner_org_editor:
-                    debug_log.debug(
-                        u"{} restricted_package_show user is an editor of owner org".format(
-                            debug_request_id
-                        )
-                    )
-                elif collaborator:
-                    debug_log.debug(
-                        u"{} restricted_package_show user is an editor collaborator of dataset".format(
-                            debug_request_id
-                        )
-                    )
-                else:
-                    debug_log.debug(
-                        u"{} restricted_package_show user is not a collaborator or editor of owner_org".format(
-                            debug_request_id
-                        )
-                    )
-
-            debug_log.debug(context)
-
         return package_metadata
 
     # Custom authorization
@@ -255,18 +221,8 @@ def restricted_package_search(context, data_dict):
             debug_request_id,
             hide_inaccessible_resources
         ))
-        debug_log.debug("{} restricted_package_search context {}".format(
-            debug_request_id,
-            context
-        ))
 
     package_search_result = package_search(context, data_dict)
-
-    if debug_logging:
-        debug_log.debug("{} restricted_package_search context after package search {}".format(
-            debug_request_id,
-            context
-        ))
 
     restricted_package_search_result = {}
 

--- a/ckanext/restricted/action.py
+++ b/ckanext/restricted/action.py
@@ -35,9 +35,8 @@ else:
     render = base.render
 
 from logging import getLogger
-
 log = getLogger(__name__)
-debug_log = getLogger('debug')
+
 
 _get_or_bust = ckan.logic.get_or_bust
 
@@ -93,11 +92,7 @@ def resource_view_list(resource_view_list, context, data_dict):
 
 @toolkit.side_effect_free
 def restricted_package_show(context, data_dict, package_metadata=None):
-
     hide_inaccessible_resources = p.toolkit.asbool(data_dict.get('hide_inaccessible_resources', False))
-    debug_logging = p.toolkit.asbool(data_dict.pop('debug_logging', False))
-    debug_request_id = data_dict.pop('debug_request_id', "")
-
     if not package_metadata:
         package_metadata = package_show(context, data_dict)
     else:
@@ -109,21 +104,9 @@ def restricted_package_show(context, data_dict, package_metadata=None):
             raise toolkit.ObjectNotFound(toolkit._('Dataset not found'))
         context['package'] = pkg
 
-    if debug_logging:
-        debug_log.debug("{} restricted_package_show for package {}".format(
-            debug_request_id,
-            package_metadata.get('name')
-        ))
-
     # Ensure user who can edit can see the resource
     if authz.is_authorized(
             'package_update', context, package_metadata).get('success', False):
-        if debug_logging:
-            debug_log.debug(
-                "{} restricted_package_show granted - user authorised to edit dataset".format(
-                    debug_request_id
-                )
-            )
         return package_metadata
 
     # Custom authorization
@@ -135,21 +118,8 @@ def restricted_package_show(context, data_dict, package_metadata=None):
     # restricted_package_metadata['resources'] = _restricted_resource_list_url(
     #     context, restricted_package_metadata.get('resources', []))
     resources = restricted_package_metadata.get('resources', [])
-
     if hide_inaccessible_resources:
-
-        if debug_logging:
-            debug_log.debug("{} restricted_package_show hiding inaccessible resources".format(
-                debug_request_id
-            ))
-
-        resources = _restricted_resource_list_accessible_by_user(
-            context,
-            resources,
-            package_dict=package_metadata,
-            debug_logging=debug_logging,
-            debug_request_id=debug_request_id
-        )
+        resources = _restricted_resource_list_accessible_by_user(context, resources, package_dict=package_metadata)
         restricted_package_metadata['num_resources'] = len(resources)
     resources = _restricted_resource_list_hide_fields(context, resources)
     restricted_package_metadata['resources'] = resources
@@ -157,18 +127,11 @@ def restricted_package_show(context, data_dict, package_metadata=None):
     return (restricted_package_metadata)
 
 
-def _restricted_resource_list_accessible_by_user(
-        context, resource_list, package_dict=None, debug_logging=False, debug_request_id=""):
+
+def _restricted_resource_list_accessible_by_user(context, resource_list, package_dict=None):
     restricted_resources_list = []
     user_name = logic.restricted_get_username_from_context(context)
     user_obj = context.get('auth_user_obj')
-
-    if debug_logging:
-        debug_log.debug("{} _restricted_resource_list_accessible_by_user user_name {}".format(
-            debug_request_id,
-            user_name
-        ))
-
     for resource in resource_list:
         resource_dict = dict(resource)
         if not package_dict:
@@ -179,14 +142,12 @@ def _restricted_resource_list_accessible_by_user(
             package_dict,
             user_obj=user_obj,
             check_access_package_show=False,
-            user_organization_dict=logic.get_organization_dict(user_name),
-            debug_logging=debug_logging,
-            debug_request_id=debug_request_id
+            user_organization_dict=logic.get_organization_dict(user_name)
         ).get('success', False)
-
         if user_has_resource_access:
             restricted_resources_list.append(resource_dict)
     return restricted_resources_list
+
 
 
 @toolkit.side_effect_free
@@ -208,20 +169,6 @@ def restricted_resource_search(context, data_dict):
 def restricted_package_search(context, data_dict):
     # pop the param as ckan package search action doesn't support any extra parameters
     hide_inaccessible_resources = p.toolkit.asbool(data_dict.pop('hide_inaccessible_resources', False))
-
-    debug_logging = p.toolkit.asbool(data_dict.pop('debug_logging', False))
-    debug_request_id = data_dict.pop('debug_request_id', "")
-
-    if debug_logging:
-        debug_log.debug("{} restricted_package_search data_dict {}".format(
-            debug_request_id,
-            data_dict
-        ))
-        debug_log.debug("{} restricted_package_search hide_inaccessible_resources {}".format(
-            debug_request_id,
-            hide_inaccessible_resources
-        ))
-
     package_search_result = package_search(context, data_dict)
 
     restricted_package_search_result = {}
@@ -232,15 +179,7 @@ def restricted_package_search(context, data_dict):
             for package in value:
                 restricted_package_search_result_list.append(
                     restricted_package_show(
-                        context,
-                        {
-                            'id': package.get('id'),
-                            'hide_inaccessible_resources': hide_inaccessible_resources,
-                            'debug_logging': debug_logging,
-                            'debug_request_id': debug_request_id
-                        },
-                        package_metadata=package
-                    )
+                        context, {'id': package.get('id'), 'hide_inaccessible_resources': hide_inaccessible_resources}, package_metadata=package)
                 )
             restricted_package_search_result[key] = \
                 restricted_package_search_result_list

--- a/ckanext/restricted/logic.py
+++ b/ckanext/restricted/logic.py
@@ -26,7 +26,6 @@ else:
 from logging import getLogger
 
 log = getLogger(__name__)
-debug_log = getLogger('debug')
 
 
 def restricted_get_username_from_context(context):
@@ -77,13 +76,7 @@ def restricted_get_restricted_dict(resource_dict):
 
 def restricted_check_user_resource_access(user, resource_dict, package_dict,
                                           user_obj=None, check_access_package_show=True,
-                                          user_organization_dict=None, debug_logging=False, debug_request_id=""):
-    if debug_logging:
-        debug_log.debug("{} restricted_check_user_resource_access resource {}".format(
-            debug_request_id,
-            resource_dict['id']
-        ))
-
+                                          user_organization_dict=None):
     # Check access to package
     if check_access_package_show:
         logic.check_access('package_show', {'user': user},
@@ -97,8 +90,6 @@ def restricted_check_user_resource_access(user, resource_dict, package_dict,
         else:
             user_id = toolkit.get_action('user_show')({'ignore_auth': True}, {'id': user})['id']
         if authz.user_is_collaborator_on_dataset(user_id, package_dict['id']):
-            if debug_logging:
-                debug_log.debug("{} restricted_check_user_resource_access granted - collaborator".format(debug_request_id))
             return {'success': True}
 
     restricted_level = restricted_dict.get('level', 'restricted')
@@ -106,41 +97,24 @@ def restricted_check_user_resource_access(user, resource_dict, package_dict,
     allowed_organizations = restricted_dict.get('allowed_organizations', [])
     # Public resources
     if restricted_level == 'public':
-        if debug_logging:
-            debug_log.debug("{} restricted_check_user_resource_access granted - public resource".format(debug_request_id))
         return {'success': True}
     # Registered user
     if not user:
-        if debug_logging:
-            debug_log.debug("{} restricted_check_user_resource_access denied - unregistered user".format(debug_request_id))
         return {
             'success': False,
             'msg': 'Resource access restricted to registered users'}
     # Since we have a user, check if it is in the allowed list
     if user in allowed_users:
-        if debug_logging:
-            debug_log.debug("{} restricted_check_user_resource_access granted - allowed user".format(debug_request_id))
         return {'success': True}
 
     if not user_organization_dict:
         user_organization_dict = get_organization_dict(user_id)
 
-    if debug_logging:
-        debug_log.debug("{} restricted_check_user_resource_access user_organization_dict {}".format(
-            debug_request_id,
-            user_organization_dict
-        ))
-
     pkg_organization_id = package_dict.get('owner_org', '')
     # Same Organization Members
     for org_id, org_name in user_organization_dict.items():
         if org_id != "" and (org_id == pkg_organization_id or org_name in allowed_organizations):
-            if debug_logging:
-                debug_log.debug("{} restricted_check_user_resource_access granted - allowed_organization".format(
-                    debug_request_id))
             return {'success': True}
-    if debug_logging:
-        debug_log.debug("{} restricted_check_user_resource_access denied - end of function".format(debug_request_id))
     return {
         'success': False,
         'msg': ('Resource access restricted')}


### PR DESCRIPTION
Debug logs were added to solve a particularly complex problem reported by Avenir health.  The problem has since been fixed under Jira issue ADX-798, and we now need to remove the debug logs from the code base. 

This reverts commit c86d1cec2bfa1118f5334fed2d5f375a94a10903, reversing changes made to 48bafbe92cd0622d480c4bc1ff797b674def67c4.

This reverts commit https://github.com/fjelltopp/ckanext-restricted/commit/48bafbe92cd0622d480c4bc1ff797b674def67c4, reversing changes made to https://github.com/fjelltopp/ckanext-restricted/commit/2bdb158da846761fc4353b5d360786b72eb39363.