### PR TITLE
ADX-980 Fix package-search slowdown

### DIFF
--- a/ckanext/restricted/action.py
+++ b/ckanext/restricted/action.py
@@ -117,8 +117,6 @@ def restricted_package_show(context, data_dict, package_metadata=None,
     else:
         restricted_package_metadata = dict(package_metadata.for_json())
 
-    # restricted_package_metadata['resources'] = _restricted_resource_list_url(
-    #     context, restricted_package_metadata.get('resources', []))
     resources = restricted_package_metadata.get('resources', [])
     if hide_inaccessible_resources:
         resources = _restricted_resource_list_accessible_by_user(context, resources, package_dict=package_metadata,
@@ -155,7 +153,6 @@ def _restricted_resource_list_accessible_by_user(context, resource_list, user_is
         if user_has_resource_access:
             restricted_resources_list.append(resource_dict)
     return restricted_resources_list
-
 
 
 @toolkit.side_effect_free
@@ -228,17 +225,6 @@ def restricted_check_access(context, data_dict):
     resource_dict = ckan.logic.get_action('resource_show')(dict(context, return_type='dict'), {'id': resource_id})
 
     return logic.restricted_check_user_resource_access(user_name, resource_dict, package_dict)
-
-# def _restricted_resource_list_url(context, resource_list):
-#     restricted_resources_list = []
-#     for resource in resource_list:
-#         authorized = auth.restricted_resource_show(
-#             context, {'id': resource.get('id'), 'resource': resource}).get('success', False)
-#         restricted_resource = dict(resource)
-#         if not authorized:
-#             restricted_resource['url'] = _('Not Authorized')
-#         restricted_resources_list += [restricted_resource]
-#     return restricted_resources_list
 
 
 def is_authorized_to_do_package_update(context, package_id):

--- a/ckanext/restricted/action.py
+++ b/ckanext/restricted/action.py
@@ -90,8 +90,17 @@ def resource_view_list(resource_view_list, context, data_dict):
 
 @toolkit.side_effect_free
 def restricted_package_show(context, data_dict, package_metadata=None,
-                            user_is_package_collaborator_cache={}, user_can_update_package_cache={},
-                            user_organization_dict={}):
+                            user_is_package_collaborator_cache=None, user_can_update_package_cache=None,
+                            user_organization_dict=None):
+    if user_is_package_collaborator_cache is None:
+        user_is_package_collaborator_cache = {}
+
+    if user_can_update_package_cache is None:
+        user_can_update_package_cache = {}
+
+    if user_organization_dict is None:
+        user_organization_dict = {}
+
     hide_inaccessible_resources = p.toolkit.asbool(data_dict.get('hide_inaccessible_resources', False))
     if not package_metadata:
         package_metadata = package_show(context, data_dict)
@@ -130,13 +139,15 @@ def restricted_package_show(context, data_dict, package_metadata=None,
     return (restricted_package_metadata)
 
 
-def _restricted_resource_list_accessible_by_user(context, resource_list, user_is_package_collaborator_cache={},
+def _restricted_resource_list_accessible_by_user(context, resource_list, user_is_package_collaborator_cache=None,
                                                  package_dict=None, user_organization_dict=None):
     restricted_resources_list = []
     user_name = logic.restricted_get_username_from_context(context)
     user_obj = context.get('auth_user_obj')
-    if not user_organization_dict:
+    if user_organization_dict is None:
         user_organization_dict = logic.get_organization_dict(user_name)
+    if user_is_package_collaborator_cache is None:
+        user_is_package_collaborator_cache = {}
     for resource in resource_list:
         resource_dict = dict(resource)
         if not package_dict:
@@ -206,7 +217,6 @@ def restricted_package_search(context, data_dict):
 
 @toolkit.side_effect_free
 def restricted_check_access(context, data_dict):
-
     package_id = data_dict.get('package_id', False)
     resource_id = data_dict.get('resource_id', False)
 
@@ -231,8 +241,11 @@ def is_authorized_to_do_package_update(context, package_id):
     return authz.is_authorized('package_update', context, {'id': package_id}).get('success')
 
 
-def _restricted_resource_list_hide_fields(context, resource_list, user_can_update_package_cache={}):
+def _restricted_resource_list_hide_fields(context, resource_list, user_can_update_package_cache=None):
     restricted_resources_list = []
+    if user_can_update_package_cache is None:
+        user_can_update_package_cache = {}
+
     for resource in resource_list:
         # copy original resource
         restricted_resource = dict(resource)

--- a/ckanext/restricted/action.py
+++ b/ckanext/restricted/action.py
@@ -2,12 +2,13 @@
 
 from __future__ import unicode_literals
 
+import json
+
 import six
 
 import ckan.authz as authz
 from ckan import model
 from ckan.common import _
-
 import ckan.lib.base as base
 from ckan.lib.mailer import mail_recipient
 from ckan.lib.mailer import MailerException
@@ -18,9 +19,7 @@ from ckan.logic.action.get import package_search
 from ckan.logic.action.get import package_show
 from ckan.logic.action.get import resource_search
 from ckan.plugins import toolkit
-
 from ckanext.restricted import logic
-import json
 
 try:
     # CKAN 2.7 and later
@@ -90,7 +89,9 @@ def resource_view_list(resource_view_list, context, data_dict):
 
 
 @toolkit.side_effect_free
-def restricted_package_show(context, data_dict, package_metadata=None):
+def restricted_package_show(context, data_dict, package_metadata=None,
+                            user_is_package_collaborator_cache={}, user_can_update_package_cache={},
+                            user_organization_dict={}):
     hide_inaccessible_resources = p.toolkit.asbool(data_dict.get('hide_inaccessible_resources', False))
     if not package_metadata:
         package_metadata = package_show(context, data_dict)
@@ -108,6 +109,8 @@ def restricted_package_show(context, data_dict, package_metadata=None):
             'package_update', context, package_metadata).get('success', False):
         return package_metadata
 
+    user_can_update_package_cache[package_metadata['id']] = False
+
     # Custom authorization
     if isinstance(package_metadata, dict):
         restricted_package_metadata = dict(package_metadata)
@@ -118,19 +121,24 @@ def restricted_package_show(context, data_dict, package_metadata=None):
     #     context, restricted_package_metadata.get('resources', []))
     resources = restricted_package_metadata.get('resources', [])
     if hide_inaccessible_resources:
-        resources = _restricted_resource_list_accessible_by_user(context, resources, package_dict=package_metadata)
+        resources = _restricted_resource_list_accessible_by_user(context, resources, package_dict=package_metadata,
+                                                                 user_is_package_collaborator_cache=user_is_package_collaborator_cache,
+                                                                 user_organization_dict=user_organization_dict)
         restricted_package_metadata['num_resources'] = len(resources)
-    resources = _restricted_resource_list_hide_fields(context, resources)
+    resources = _restricted_resource_list_hide_fields(context, resources,
+                                                      user_can_update_package_cache=user_can_update_package_cache)
     restricted_package_metadata['resources'] = resources
 
     return (restricted_package_metadata)
 
 
-
-def _restricted_resource_list_accessible_by_user(context, resource_list, package_dict=None):
+def _restricted_resource_list_accessible_by_user(context, resource_list, user_is_package_collaborator_cache={},
+                                                 package_dict=None, user_organization_dict=None):
     restricted_resources_list = []
     user_name = logic.restricted_get_username_from_context(context)
     user_obj = context.get('auth_user_obj')
+    if not user_organization_dict:
+        user_organization_dict = logic.get_organization_dict(user_name)
     for resource in resource_list:
         resource_dict = dict(resource)
         if not package_dict:
@@ -139,9 +147,10 @@ def _restricted_resource_list_accessible_by_user(context, resource_list, package
             user_name,
             resource_dict,
             package_dict,
+            user_is_package_collaborator_cache=user_is_package_collaborator_cache,
             user_obj=user_obj,
             check_access_package_show=False,
-            user_organization_dict=logic.get_organization_dict(user_name)
+            user_organization_dict=user_organization_dict
         ).get('success', False)
         if user_has_resource_access:
             restricted_resources_list.append(resource_dict)
@@ -152,12 +161,15 @@ def _restricted_resource_list_accessible_by_user(context, resource_list, package
 @toolkit.side_effect_free
 def restricted_resource_search(context, data_dict):
     hide_inaccessible_resources = p.toolkit.asbool(data_dict.get('hide_inaccessible_resources', False))
+    user_can_update_package_cache = {}
+    user_is_package_collaborator_cache = {}
 
     resource_search_result = resource_search(context, data_dict)
     results = resource_search_result['results']
     if hide_inaccessible_resources:
-        results = _restricted_resource_list_accessible_by_user(context, results)
-    results = _restricted_resource_list_hide_fields(context, results)
+        results = _restricted_resource_list_accessible_by_user(context, results, user_is_package_collaborator_cache)
+    results = _restricted_resource_list_hide_fields(context, results,
+                                                    user_can_update_package_cache=user_can_update_package_cache)
     count = len(results)
 
     resource_search_result.update({'count': count, 'results': results})
@@ -169,6 +181,10 @@ def restricted_package_search(context, data_dict):
     # pop the param as ckan package search action doesn't support any extra parameters
     hide_inaccessible_resources = p.toolkit.asbool(data_dict.pop('hide_inaccessible_resources', False))
     package_search_result = package_search(context, data_dict)
+    user_can_update_package_cache = {}
+    user_is_package_collaborator_cache = {}
+    user_name = logic.restricted_get_username_from_context(context)
+    user_organization_dict = logic.get_organization_dict(user_name)
 
     restricted_package_search_result = {}
 
@@ -178,7 +194,10 @@ def restricted_package_search(context, data_dict):
             for package in value:
                 restricted_package_search_result_list.append(
                     restricted_package_show(
-                        context, {'id': package.get('id'), 'hide_inaccessible_resources': hide_inaccessible_resources}, package_metadata=package)
+                        context, {'id': package.get('id'), 'hide_inaccessible_resources': hide_inaccessible_resources},
+                        package_metadata=package, user_is_package_collaborator_cache=user_is_package_collaborator_cache,
+                        user_can_update_package_cache=user_can_update_package_cache,
+                        user_organization_dict=user_organization_dict)
                 )
             restricted_package_search_result[key] = \
                 restricted_package_search_result_list
@@ -222,7 +241,11 @@ def restricted_check_access(context, data_dict):
 #     return restricted_resources_list
 
 
-def _restricted_resource_list_hide_fields(context, resource_list):
+def is_authorized_to_do_package_update(context, package_id):
+    return authz.is_authorized('package_update', context, {'id': package_id}).get('success')
+
+
+def _restricted_resource_list_hide_fields(context, resource_list, user_can_update_package_cache={}):
     restricted_resources_list = []
     for resource in resource_list:
         # copy original resource
@@ -232,10 +255,11 @@ def _restricted_resource_list_hide_fields(context, resource_list):
         restricted_dict = logic.restricted_get_restricted_dict(restricted_resource)
 
         # hide other fields in restricted to everyone but dataset owner(s)
-        if not authz.is_authorized(
-                'package_update', context, {'id': resource.get('package_id')}
-                ).get('success'):
+        package_id = resource.get('package_id')
+        if package_id not in user_can_update_package_cache:
+            user_can_update_package_cache[package_id] = is_authorized_to_do_package_update(context, package_id)
 
+        if not user_can_update_package_cache[package_id]:
             user_name = logic.restricted_get_username_from_context(context)
 
             # hide partially other allowed user_names (keep own)

--- a/ckanext/restricted/logic.py
+++ b/ckanext/restricted/logic.py
@@ -1,15 +1,17 @@
 # coding: utf8
 
 from __future__ import unicode_literals
+
+import json
+
+import six
+
 import ckan.authz as authz
 from ckan.common import _
-
 import ckan.lib.base as base
 import ckan.lib.mailer as mailer
 import ckan.logic as logic
 import ckan.plugins.toolkit as toolkit
-import json
-import six
 
 try:
     # CKAN 2.7 and later
@@ -74,13 +76,13 @@ def restricted_get_restricted_dict(resource_dict):
     return restricted_dict
 
 
-def restricted_check_user_resource_access(user, resource_dict, package_dict,
+def restricted_check_user_resource_access(user, resource_dict, package_dict, user_is_package_collaborator_cache={},
                                           user_obj=None, check_access_package_show=True,
                                           user_organization_dict=None):
     # Check access to package
+    package_id = package_dict['id']
     if check_access_package_show:
-        logic.check_access('package_show', {'user': user},
-                           {'id': package_dict['id']})
+        logic.check_access('package_show', {'user': user}, {'id': package_id})
 
     restricted_dict = restricted_get_restricted_dict(resource_dict)
 
@@ -89,7 +91,11 @@ def restricted_check_user_resource_access(user, resource_dict, package_dict,
             user_id = user_obj.id
         else:
             user_id = toolkit.get_action('user_show')({'ignore_auth': True}, {'id': user})['id']
-        if authz.user_is_collaborator_on_dataset(user_id, package_dict['id']):
+
+        if package_id not in user_is_package_collaborator_cache:
+            user_is_package_collaborator_cache[package_id] = authz.user_is_collaborator_on_dataset(user_id, package_id)
+
+        if user_is_package_collaborator_cache[package_id]:
             return {'success': True}
 
     restricted_level = restricted_dict.get('level', 'restricted')

--- a/ckanext/restricted/logic.py
+++ b/ckanext/restricted/logic.py
@@ -76,10 +76,13 @@ def restricted_get_restricted_dict(resource_dict):
     return restricted_dict
 
 
-def restricted_check_user_resource_access(user, resource_dict, package_dict, user_is_package_collaborator_cache={},
+def restricted_check_user_resource_access(user, resource_dict, package_dict, user_is_package_collaborator_cache=None,
                                           user_obj=None, check_access_package_show=True,
                                           user_organization_dict=None):
     # Check access to package
+    if user_is_package_collaborator_cache is None:
+        user_is_package_collaborator_cache = {}
+
     package_id = package_dict['id']
     if check_access_package_show:
         logic.check_access('package_show', {'user': user}, {'id': package_id})
@@ -113,7 +116,7 @@ def restricted_check_user_resource_access(user, resource_dict, package_dict, use
     if user in allowed_users:
         return {'success': True}
 
-    if not user_organization_dict:
+    if user_organization_dict is None:
         user_organization_dict = get_organization_dict(user_id)
 
     pkg_organization_id = package_dict.get('owner_org', '')

--- a/ckanext/restricted/tests/test_performance_package_search.py
+++ b/ckanext/restricted/tests/test_performance_package_search.py
@@ -1,17 +1,16 @@
 # encoding: utf-8
 import time
 import os.path
-
-from ckan.tests import helpers
 import logging
-import pytest
-from ckan.common import config
 import subprocess
 
+import pytest
+
+from ckan.tests import helpers
+from ckan.common import config
 import ckanext.restricted.action
 import ckanext.restricted.plugin
 import ckanext.restricted.tests.assets.old_action
-
 
 log = logging.getLogger(__name__)
 
@@ -81,12 +80,18 @@ class Helper:
 class TestRestrictedSearchPerformance:
 
     def test_performance(self):
-        avg_time = self.get_avg_run_time(self._perform_search)
-        old_avg_time = self.get_avg_run_time(self._perform_old_search)
+        avg_time = self.get_avg_run_time(self._perform_search, False)
+        old_avg_time = self.get_avg_run_time(self._perform_old_search, False)
 
-        log.warning(f"Avg time: {avg_time}, old avg time: {old_avg_time}")
+        assert 5 * avg_time <= old_avg_time
 
-    def get_avg_run_time(self, search_function):
+    def test_performance_hide_enabled(self):
+        avg_time = self.get_avg_run_time(self._perform_search, True)
+        old_avg_time = self.get_avg_run_time(self._perform_old_search, True)
+
+        assert 9 * avg_time <= old_avg_time
+
+    def get_avg_run_time(self, search_function, hide_inaccessible_resources):
         context = {
             'ignore_auth': False,
             'user': 'test_user_00'
@@ -97,23 +102,23 @@ class TestRestrictedSearchPerformance:
 
         for i in range(0, iter_count):
             start = time.perf_counter()
-            result = search_function(context)
+            result = search_function(context, hide_inaccessible_resources)
             end = time.perf_counter()
             cumulative_time += end - start
             assert result['count'] == 299
 
         return cumulative_time / iter_count
 
-    def _perform_search(self, context):
+    def _perform_search(self, context, hide_inaccessible_resources):
         return helpers.call_action(
             'package_search',
             context,
-            q="title:Dataset"
+            q="title:Dataset", hide_inaccessible_resources=hide_inaccessible_resources
         )
 
-    def _perform_old_search(self, context):
+    def _perform_old_search(self, context, hide_inaccessible_resources=False):
         return helpers.call_action(
             'package_search_old',
             context,
-            q="title:Dataset"
+            q="title:Dataset", hide_inaccessible_resources=hide_inaccessible_resources
         )


### PR DESCRIPTION
## ADX-980 Fix package-search slowdown when using ckanext-restricted

## Description

Ckanext-restricted adds additional layer to 'package-search' action, namely after searching for datasets there is a check for access to all resources from found datasets. Additionally, there is an option 'hide_inaccessible_resources' that allows hiding inaccessible resources which also checks access rights.

Profiling using python's cProfile showed 2 places eligible for quick performance improvement by caching results:
1. While checking access for a resource first there are calls to `auth.is_authorized('package_search')` and `auth.user_is_collaborator_on_dataset(dataset_id)` on a parent dataset. Since datasets often have more than 1 resource, caching these results improves performance.
2. Another place is call to `logic_get_organization_dict(user_name)` - this was called for each resource and dataset, so caching improved performance dramatically.

Abovementioned improvements will work for specific conditions, namely when search results return datasets that have more than 1 resource. If some production system has this case, more thorough investigation is required. At that point one might speedup calls to `auth.is_authorized('package_update')` by modyfing it and caching results of some of its inner calls (like 'is_sysadmin' or whole org structure for user, that is being dragged from database with each call) - however a risk will arise that further changes in CKAN in `auth.is_authorized` might break this solution. 


## Testing (delete if not applicable)

Performance test has been modified to make sure improvement is at least 5x for calls with `hide_inaccessible_resources=False` and 9x for calls with `hide_inaccessible_resources=True`.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [x] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
