### PR TITLE
ADX-978 Download link for resources from old activitiy view errors

### DIFF
--- a/ckanext/restricted/auth.py
+++ b/ckanext/restricted/auth.py
@@ -15,7 +15,7 @@ def restricted_resource_show(context, data_dict=None):
     # Ensure user who can edit the package can see the resource
     resource = data_dict.get('resource', context.get('resource', {}))
     if not resource:
-        extract_id_from_id_contactenated_with_activity_id(data_dict)
+        extract_id_from_id_concatenated_with_activity_id(data_dict)
         resource = logic_auth.get_resource_object(context, data_dict)
     if type(resource) is not dict:
         resource = resource.as_dict()
@@ -37,8 +37,8 @@ def restricted_resource_show(context, data_dict=None):
         user_name, resource, package))
 
 
-def extract_id_from_id_contactenated_with_activity_id(data_dict):
-    if 'id' in data_dict and '/' in data_dict['id']:
+def extract_id_from_id_concatenated_with_activity_id(data_dict):
+    if '/' in data_dict.get('id', ''):
         data_dict['id'] = data_dict['id'].split('/')[0]
 
 

--- a/ckanext/restricted/auth.py
+++ b/ckanext/restricted/auth.py
@@ -15,6 +15,7 @@ def restricted_resource_show(context, data_dict=None):
     # Ensure user who can edit the package can see the resource
     resource = data_dict.get('resource', context.get('resource', {}))
     if not resource:
+        extract_id_from_id_contactenated_with_activity_id(data_dict)
         resource = logic_auth.get_resource_object(context, data_dict)
     if type(resource) is not dict:
         resource = resource.as_dict()
@@ -34,6 +35,11 @@ def restricted_resource_show(context, data_dict=None):
 
     return (logic.restricted_check_user_resource_access(
         user_name, resource, package))
+
+
+def extract_id_from_id_contactenated_with_activity_id(data_dict):
+    if 'id' in data_dict and '/' in data_dict['id']:
+        data_dict['id'] = data_dict['id'].split('/')[0]
 
 
 def logged_in(context, data_dict=None):

--- a/ckanext/restricted/tests/test_auth.py
+++ b/ckanext/restricted/tests/test_auth.py
@@ -1,0 +1,42 @@
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from ckanext.restricted.auth import restricted_resource_show
+
+
+@pytest.mark.usefixtures(u'clean_db')
+@pytest.mark.usefixtures(u'clean_index')
+@pytest.mark.ckan_config(u'ckan.plugins', u'restricted')
+@pytest.mark.usefixtures(u'with_plugins')
+@pytest.mark.usefixtures(u'with_request_context')
+class TestAuth:
+    @patch('ckanext.restricted.auth.authz')
+    @patch('ckanext.restricted.auth.logic_auth')
+    def test_user_can_check_access_for_resource_within_activity(self, logic_auth, authz):
+        res = {'package_id': '42'}
+        logic_auth.get_resource_object = MagicMock(return_value=res)
+        authz.is_authorized = MagicMock(return_value={'success': True})
+        context = {}
+        data_dict = {'id': '14aeaaa7-730e-4197-9a90-18f4a8509ce3/984412af-c948-459c-815a-84ad3a635163'}
+
+        expected_data_dict = {'id': '14aeaaa7-730e-4197-9a90-18f4a8509ce3'}
+
+        assert restricted_resource_show(context, data_dict) == {'success': True}
+        logic_auth.get_resource_object.assert_called_once_with(context, expected_data_dict)
+        authz.is_authorized.assert_called_once_with('package_update', context, {'id': '42'})
+
+    @patch('ckanext.restricted.auth.authz')
+    @patch('ckanext.restricted.auth.logic_auth')
+    def test_user_can_check_access_for_resource(self, logic_auth, authz):
+        res = {'package_id': '42'}
+        logic_auth.get_resource_object = MagicMock(return_value=res)
+        authz.is_authorized = MagicMock(return_value={'success': True})
+        context = {}
+        data_dict = {'id': '14aeaaa7-730e-4197-9a90-18f4a8509ce3'}
+
+        expected_data_dict = {'id': '14aeaaa7-730e-4197-9a90-18f4a8509ce3'}
+
+        assert restricted_resource_show(context, data_dict) == {'success': True}
+        logic_auth.get_resource_object.assert_called_once_with(context, expected_data_dict)
+        authz.is_authorized.assert_called_once_with('package_update', context, {'id': '42'})

--- a/ckanext/restricted/tests/test_plugin.py
+++ b/ckanext/restricted/tests/test_plugin.py
@@ -7,6 +7,8 @@ import logging
 from ckan.lib.base import render_snippet
 from pprint import pformat
 import pytest
+from unittest.mock import patch, MagicMock
+from ckanext.restricted.auth import restricted_resource_show
 
 log = logging.getLogger(__name__)
 
@@ -321,7 +323,6 @@ class TestRestrictedPlugin(object):
                 datasets_count += 1
         assert datasets_count == 1
 
-
     @pytest.mark.ckan_config(u'ckan.auth.allow_dataset_collaborators', 'true')
     def test_collaborator_overrides_restricted_settings(self):
         dataset, other, other_resource, org_resource = self._two_users_one_package_two_resources_one_restricted()
@@ -476,3 +477,33 @@ class TestRestrictedPlugin(object):
             '{}">{}</a>'.format(org['name'], org['title'])
         )
         assert expected in html4
+
+    @patch('ckanext.restricted.auth.authz')
+    @patch('ckanext.restricted.auth.logic_auth')
+    def test_user_can_check_access_for_resource_within_activity(self, logic_auth, authz):
+        res = {'package_id': '42'}
+        logic_auth.get_resource_object = MagicMock(return_value=res)
+        authz.is_authorized = MagicMock(return_value={'success': True})
+        context = {}
+        data_dict = {'id': '14aeaaa7-730e-4197-9a90-18f4a8509ce3/984412af-c948-459c-815a-84ad3a635163'}
+
+        expected_data_dict = {'id': '14aeaaa7-730e-4197-9a90-18f4a8509ce3'}
+
+        assert restricted_resource_show(context, data_dict) == {'success': True}
+        logic_auth.get_resource_object.assert_called_once_with(context, expected_data_dict)
+        authz.is_authorized.assert_called_once_with('package_update', context, {'id': '42'})
+
+    @patch('ckanext.restricted.auth.authz')
+    @patch('ckanext.restricted.auth.logic_auth')
+    def test_user_can_check_access_for_resource(self, logic_auth, authz):
+        res = {'package_id': '42'}
+        logic_auth.get_resource_object = MagicMock(return_value=res)
+        authz.is_authorized = MagicMock(return_value={'success': True})
+        context = {}
+        data_dict = {'id': '14aeaaa7-730e-4197-9a90-18f4a8509ce3'}
+
+        expected_data_dict = {'id': '14aeaaa7-730e-4197-9a90-18f4a8509ce3'}
+
+        assert restricted_resource_show(context, data_dict) == {'success': True}
+        logic_auth.get_resource_object.assert_called_once_with(context, expected_data_dict)
+        authz.is_authorized.assert_called_once_with('package_update', context, {'id': '42'})

--- a/ckanext/restricted/tests/test_plugin.py
+++ b/ckanext/restricted/tests/test_plugin.py
@@ -7,8 +7,6 @@ import logging
 from ckan.lib.base import render_snippet
 from pprint import pformat
 import pytest
-from unittest.mock import patch, MagicMock
-from ckanext.restricted.auth import restricted_resource_show
 
 log = logging.getLogger(__name__)
 
@@ -477,33 +475,3 @@ class TestRestrictedPlugin(object):
             '{}">{}</a>'.format(org['name'], org['title'])
         )
         assert expected in html4
-
-    @patch('ckanext.restricted.auth.authz')
-    @patch('ckanext.restricted.auth.logic_auth')
-    def test_user_can_check_access_for_resource_within_activity(self, logic_auth, authz):
-        res = {'package_id': '42'}
-        logic_auth.get_resource_object = MagicMock(return_value=res)
-        authz.is_authorized = MagicMock(return_value={'success': True})
-        context = {}
-        data_dict = {'id': '14aeaaa7-730e-4197-9a90-18f4a8509ce3/984412af-c948-459c-815a-84ad3a635163'}
-
-        expected_data_dict = {'id': '14aeaaa7-730e-4197-9a90-18f4a8509ce3'}
-
-        assert restricted_resource_show(context, data_dict) == {'success': True}
-        logic_auth.get_resource_object.assert_called_once_with(context, expected_data_dict)
-        authz.is_authorized.assert_called_once_with('package_update', context, {'id': '42'})
-
-    @patch('ckanext.restricted.auth.authz')
-    @patch('ckanext.restricted.auth.logic_auth')
-    def test_user_can_check_access_for_resource(self, logic_auth, authz):
-        res = {'package_id': '42'}
-        logic_auth.get_resource_object = MagicMock(return_value=res)
-        authz.is_authorized = MagicMock(return_value={'success': True})
-        context = {}
-        data_dict = {'id': '14aeaaa7-730e-4197-9a90-18f4a8509ce3'}
-
-        expected_data_dict = {'id': '14aeaaa7-730e-4197-9a90-18f4a8509ce3'}
-
-        assert restricted_resource_show(context, data_dict) == {'success': True}
-        logic_auth.get_resource_object.assert_called_once_with(context, expected_data_dict)
-        authz.is_authorized.assert_called_once_with('package_update', context, {'id': '42'})


### PR DESCRIPTION
## ADX-978 Download link for resources from old activitiy view errors

Allow searching for resource when its id is in form of `resource_id/activity_id`.

When accessing resource via activity, starting from blob storage code dives deeply into auth-service, where at the end a check for access to package and resource is being made. Since it's in form of
```
auth.is_authorized('resource_show')
```
and ckanext-restricted 'hijacks' this action, plugin needed to be fixed to allow this check. Because id was in form of `resource_id/activity_id` code couldn't find this object and threw 403, which redirected user to auth0.

Added unit tests for given feature.

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [x] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
