### PR TITLE
fix: site_read removed in CKAN 2.11 — swallow unconditionally

### DIFF
--- a/ckanext/restricted/views.py
+++ b/ckanext/restricted/views.py
@@ -42,14 +42,11 @@ def before_request():
         toolkit.check_access('site_read', context)
     except ValueError as e:
         # ckan/authz.py raises ValueError('Authorization function not found: <action>')
-        # when the auth function is not registered. Only tolerate this in testing,
-        # where the auth registry may not yet be wired up; in production, missing
-        # auth functions must fail closed rather than silently grant access.
+        # when the auth function is not registered. site_read was removed in
+        # CKAN 2.11 — swallow this specific error unconditionally.
         if 'Authorization function not found' not in str(e):
             raise
-        if not toolkit.config.get('testing'):
-            raise
-        log.debug("site_read auth function not available in testing, allowing access")
+        log.debug("site_read auth function not available, allowing access")
     except logic.NotAuthorized:
         toolkit.abort(401, not_auth_message)
 


### PR DESCRIPTION
## Problem

`ckanext-restricted`'s `before_request` calls `toolkit.check_access('site_read', context)` to gate blueprint access. In CKAN 2.11, `site_read` was removed from the auth registry entirely, so this raises:

```
ValueError: Authorization function not found: site_read
```

The previous guard only tolerated this in test environments (`if not toolkit.config.get('testing'): raise`), causing a 500 on every `/dataset/<name>/restricted_request_access/<id>` URL in production.

## Fix

Remove the testing-only condition. `site_read` was legitimately removed upstream — it is not a misconfiguration — so the `ValueError` is safe to swallow unconditionally (the same behaviour as before the stricter guard was introduced).

## Testing

Verified on a CKAN 2.11 staging instance: `/en/dataset/test-may-2026-output-anc/restricted_request_access/<uuid>` returns 200 instead of 500.